### PR TITLE
run 'go vet' as part of test suite; colorize test suite

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -2,6 +2,14 @@
 
 result=0
 
+function green {
+    echo -e "$(tput setaf 2)$1$(tput setaf 9)"
+}
+
+function red {
+    echo -e "$(tput setaf 1)$1$(tput setaf 9)"
+}
+
 packages=(
     deaagent
     loggregator
@@ -16,22 +24,36 @@ packages=(
 
 for package in "${packages[@]}"
 do
-    echo -e "\n Testing package $package"
+    local_result=$result
+    echo -e "\n Testing $package"
     $(dirname $0)/go fmt $package
     $(dirname $0)/go test -i --race $package
     $(dirname $0)/go test -v --race $package
     let "result += $?"
+    echo -e "\n Vetting $package"
+    $(dirname $0)/go vet $package
+    let "result += $?"
+    if [ $result -gt $local_result ]; then
+        red " Package $package FAILED"
+    else
+        green " Package $package PASSED"
+    fi
 done
 
 echo -e "\n Running build script to confirm main compiles"
-$(dirname $0)/build
-let "result += $?"
+build_status=$($(dirname $0)/build)$?
+let "result += $build_status"
+if [ $build_status -eq 0 ]; then
+    green " build script SUCCESS"
+else
+    red " build script FAILURE"
+fi
 rm -f deaagent loggregator
 
 if [ $result -eq 0 ]; then
-	echo -e "\nSUITE SUCCESS"
+	green "\nSUITE SUCCESS"
 else
-	echo -e "\nSUITE FAILURE"
+	red "\nSUITE FAILURE"
 fi
 
 exit $result

--- a/server/src/loggregator/agentlistener/agent_listener.go
+++ b/server/src/loggregator/agentlistener/agent_listener.go
@@ -49,11 +49,11 @@ func (agentListener *agentListener) Start() chan []byte {
 }
 
 func (agentListener *agentListener) Emit() instrumentation.Context {
-	return instrumentation.Context{"agentListener",
-		[]instrumentation.Metric{
-			instrumentation.Metric{"currentBufferCount", len(agentListener.dataChannel)},
-			instrumentation.Metric{"receivedMessageCount", atomic.LoadUint64(agentListener.receivedMessageCount)},
-			instrumentation.Metric{"receivedByteCount", atomic.LoadUint64(agentListener.receivedByteCount)},
+	return instrumentation.Context{Name: "agentListener",
+		Metrics: []instrumentation.Metric{
+			instrumentation.Metric{Name: "currentBufferCount", Value: len(agentListener.dataChannel)},
+			instrumentation.Metric{Name: "receivedMessageCount", Value: atomic.LoadUint64(agentListener.receivedMessageCount)},
+			instrumentation.Metric{Name: "receivedByteCount", Value: atomic.LoadUint64(agentListener.receivedByteCount)},
 		},
 	}
 }

--- a/server/src/loggregator/loggregator/main.go
+++ b/server/src/loggregator/loggregator/main.go
@@ -70,7 +70,7 @@ func (c *Config) validate(logger *gosteno.Logger) (err error) {
 	c.mbusClient.SetLogger(logger)
 	err = c.mbusClient.Connect()
 	if err != nil {
-		return errors.New(fmt.Sprintf("Could not connect to NATS: ", err.Error()))
+		return errors.New(fmt.Sprintf("Could not connect to NATS: %s", err.Error()))
 	}
 	return nil
 }

--- a/server/src/loggregator/sink/sink.go
+++ b/server/src/loggregator/sink/sink.go
@@ -99,10 +99,10 @@ func (sink *sink) Run(sinkCloseChan chan chan []byte) {
 }
 
 func (sink *sink) Emit() instrumentation.Context {
-	return instrumentation.Context{"cfSink",
-		[]instrumentation.Metric{
-			instrumentation.Metric{"sentMessageCount:" + sink.target.Identifier(), atomic.LoadUint64(sink.sentMessageCount)},
-			instrumentation.Metric{"sentByteCount:" + sink.target.Identifier(), atomic.LoadUint64(sink.sentByteCount)},
+	return instrumentation.Context{Name: "cfSink",
+		Metrics: []instrumentation.Metric{
+			instrumentation.Metric{Name: "sentMessageCount:" + sink.target.Identifier(), Value: atomic.LoadUint64(sink.sentMessageCount)},
+			instrumentation.Metric{Name: "sentByteCount:" + sink.target.Identifier(), Value: atomic.LoadUint64(sink.sentByteCount)},
 		},
 	}
 }

--- a/server/src/loggregator/sink/sink_server.go
+++ b/server/src/loggregator/sink/sink_server.go
@@ -130,7 +130,7 @@ func (sinkServer *sinkServer) Emit() instrumentation.Context {
 	return instrumentation.Context{
 		Name: "sinkServer",
 		Metrics: []instrumentation.Metric{
-			instrumentation.Metric{"numberOfSinks", sinkServer.listenerChannels.NumberOfChannels()},
+			instrumentation.Metric{Name: "numberOfSinks", Value: sinkServer.listenerChannels.NumberOfChannels()},
 		},
 	}
 }

--- a/server/src/loggregator/sink/sink_server_test.go
+++ b/server/src/loggregator/sink/sink_server_test.go
@@ -138,7 +138,7 @@ func TestDropUnmarshallableMessage(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 	select {
 	case msg1 := <-receivedChan:
-		t.Error("We should not have received a message, but got: %v", msg1)
+		t.Errorf("We should not have received a message, but got: %v", msg1)
 	default:
 		//no communication. That's good!
 	}
@@ -220,7 +220,7 @@ func TestKeepAlive(t *testing.T) {
 
 	select {
 	case msg1 := <-receivedChan:
-		t.Error("We should not have received a message, but got: %v", msg1)
+		t.Errorf("We should not have received a message, but got: %v", msg1)
 	default:
 		//no communication. That's good!
 	}

--- a/sources/deaagent/src/deaagent/logging_stream.go
+++ b/sources/deaagent/src/deaagent/logging_stream.go
@@ -82,10 +82,10 @@ func (ls *loggingStream) listen() {
 }
 
 func (ls *loggingStream) Emit() instrumentation.Context {
-	return instrumentation.Context{"loggingStream:" + ls.inst.wardenContainerPath + " type " + socketName(ls.messageType),
-		[]instrumentation.Metric{
-			instrumentation.Metric{"receivedMessageCount", atomic.LoadUint64(ls.messagesReceived)},
-			instrumentation.Metric{"receivedByteCount", atomic.LoadUint64(ls.bytesReceived)},
+	return instrumentation.Context{Name: "loggingStream:" + ls.inst.wardenContainerPath + " type " + socketName(ls.messageType),
+		Metrics: []instrumentation.Metric{
+			instrumentation.Metric{Name: "receivedMessageCount", Value: atomic.LoadUint64(ls.messagesReceived)},
+			instrumentation.Metric{Name: "receivedByteCount", Value: atomic.LoadUint64(ls.bytesReceived)},
 		},
 	}
 }


### PR DESCRIPTION
From 'godoc vet':

```
Vet examines Go source code and reports suspicious constructs, such as
Printf calls whose arguments do not align with the format string. Vet
uses heuristics that do not guarantee all reports are genuine problems,
but it can find errors not caught by the compilers.
```
