### PR TITLE
Fix port conflict issue for All-in-One loggregator & traffic_controller

### DIFF
--- a/src/trafficcontroller/trafficcontroller/main_test.go
+++ b/src/trafficcontroller/trafficcontroller/main_test.go
@@ -37,3 +37,73 @@ func TestOutgoingProxyConfigWithTwoAZs(t *testing.T) {
 	hashers := makeHashers(config.Loggregators, 3456, loggertesthelper.Logger())
 	assert.Equal(t, len(hashers), 2)
 }
+
+func TestConfigWithEmptyLoggregatorIncomingPort(t *testing.T) {
+	config := &Config{
+		IncomingPort: 3456,
+		SystemDomain: "192.168.1.10.xip.io",
+		Loggregators: map[string][]string{
+			"z1": []string{"10.244.0.14"},
+			"z2": []string{"10.244.0.14"},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		config.validate(loggertesthelper.Logger())
+	})
+	assert.Equal(t, config.IncomingPort, uint32(3456))
+	assert.Equal(t, config.LoggregatorIncomingPort, uint32(3456))
+}
+
+func TestConfigWithLoggregatorIncomingPort(t *testing.T) {
+	config := &Config{
+		IncomingPort:            3456,
+		LoggregatorIncomingPort: 13456,
+		SystemDomain:            "192.168.1.10.xip.io",
+		Loggregators: map[string][]string{
+			"z1": []string{"10.244.0.14"},
+			"z2": []string{"10.244.0.14"},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		config.validate(loggertesthelper.Logger())
+	})
+	assert.Equal(t, config.IncomingPort, uint32(3456))
+	assert.Equal(t, config.LoggregatorIncomingPort, uint32(13456))
+}
+
+func TestConfigWithEmptyLoggregatorOutgoingPort(t *testing.T) {
+	config := &Config{
+		OutgoingPort: 8080,
+		SystemDomain: "192.168.1.10.xip.io",
+		Loggregators: map[string][]string{
+			"z1": []string{"10.244.0.14"},
+			"z2": []string{"10.244.0.14"},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		config.validate(loggertesthelper.Logger())
+	})
+	assert.Equal(t, config.OutgoingPort, uint32(8080))
+	assert.Equal(t, config.LoggregatorOutgoingPort, uint32(8080))
+}
+
+func TestConfigWithLoggregatorOutgoingPort(t *testing.T) {
+	config := &Config{
+		OutgoingPort:            8080,
+		LoggregatorOutgoingPort: 18080,
+		SystemDomain:            "192.168.1.10.xip.io",
+		Loggregators: map[string][]string{
+			"z1": []string{"10.244.0.14"},
+			"z2": []string{"10.244.0.14"},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		config.validate(loggertesthelper.Logger())
+	})
+	assert.Equal(t, config.OutgoingPort, uint32(8080))
+	assert.Equal(t, config.LoggregatorOutgoingPort, uint32(18080))
+}


### PR DESCRIPTION
test result

```
Testing trafficcontroller/trafficcontroller
=== RUN TestOutgoingProxyConfigWithEmptyAZ
--- PASS: TestOutgoingProxyConfigWithEmptyAZ (0.00 seconds)
=== RUN TestOutgoingProxyConfigWithTwoAZs
--- PASS: TestOutgoingProxyConfigWithTwoAZs (0.00 seconds)
=== RUN TestConfigWithEmptyLoggregatorIncomingPort
--- PASS: TestConfigWithEmptyLoggregatorIncomingPort (0.00 seconds)
=== RUN TestConfigWithLoggregatorIncomingPort
--- PASS: TestConfigWithLoggregatorIncomingPort (0.00 seconds)
=== RUN TestConfigWithEmptyLoggregatorOutgoingPort
--- PASS: TestConfigWithEmptyLoggregatorOutgoingPort (0.00 seconds)
=== RUN TestConfigWithLoggregatorOutgoingPort
--- PASS: TestConfigWithLoggregatorOutgoingPort (0.00 seconds)
PASS
ok trafficcontroller/trafficcontroller 1.012s

Vetting trafficcontroller/trafficcontroller
Package trafficcontroller/trafficcontroller PASSED

SUITE SUCCESS
```
