### PR TITLE
Add flag uaa.no_ssl support

### DIFF
--- a/bosh/jobs/loggregator_trafficcontroller/spec
+++ b/bosh/jobs/loggregator_trafficcontroller/spec
@@ -43,6 +43,9 @@ properties:
     default: "doppler"
   uaa.clients.doppler.secret:
     description: "Doppler's client secret to connect to UAA"
+  uaa.no_ssl:
+    description: "when true, uaa uses http, otherwise it uses https"
+    default: false
   metron_endpoint.dropsonde_port:
     description: "The port used to emit dropsonde messages to the Metron agent"
     default: 3457

--- a/bosh/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller.json.erb
+++ b/bosh/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller.json.erb
@@ -22,7 +22,7 @@
     "VarzPort": <%= p("traffic_controller.status.port") %>,
     "MetronPort": <%= p("metron_endpoint.dropsonde_port") %>,
     "CollectorRegistrarIntervalMilliseconds": <%= p("traffic_controller.collector_registrar_interval_milliseconds") %>,
-    "UaaHost": "https://uaa.<%= p("system_domain") %>",
+    "UaaHost": "<%= p("uaa.no_ssl") ? "http" : "https"%>://uaa.<%= p("system_domain") %>",
     "UaaClientId": "<%= p("doppler.uaa_client_id") %>",
     "UaaClientSecret": "<%= p("uaa.clients.doppler.secret") %>"
     <% if_p("syslog_daemon_config") do |_| %>


### PR DESCRIPTION
Honor no_ssl flag for uaa.
Related to https://www.pivotaltracker.com/story/show/84775914
and https://groups.google.com/a/cloudfoundry.org/forum/#!topic/vcap-dev/OI03nzH2pqE
Thanks
