### PR TITLE
Expose batching configuration as Bosh properties

### DIFF
--- a/jobs/doppler/spec
+++ b/jobs/doppler/spec
@@ -126,3 +126,10 @@ properties:
   metron_endpoint.grpc_port:
     description: "The port used to emit grpc messages to the Metron agent"
     default: 3458
+
+  doppler.batch.interval:
+    description: "EXPERIMENTAL: Batching interval for v1 egressing"
+    default: 500000000
+  doppler.batch.size:
+    description: "EXPERIMENTAL: Batching size for v1 egressing"
+    default: 100

--- a/jobs/doppler/templates/doppler.json.erb
+++ b/jobs/doppler/templates/doppler.json.erb
@@ -56,7 +56,7 @@
             a[:BlackListIPs] = prop
         end
         a[:BatchSize] = p('doppler.batch.size')
-        a[:Interval] = p('doppler.batch.interval')
+        a[:BatchInterval] = p('doppler.batch.interval')
     end
 %>
 <%= JSON.pretty_generate(args) %>

--- a/jobs/doppler/templates/doppler.json.erb
+++ b/jobs/doppler/templates/doppler.json.erb
@@ -55,6 +55,8 @@
         if_p("doppler.blacklisted_syslog_ranges") do |prop|
             a[:BlackListIPs] = prop
         end
+        a[:BatchSize] = p('doppler.batch.size')
+        a[:Interval] = p('doppler.batch.interval')
     end
 %>
 <%= JSON.pretty_generate(args) %>

--- a/jobs/metron_agent/spec
+++ b/jobs/metron_agent/spec
@@ -79,3 +79,10 @@ properties:
   metron_agent.health_port:
     description: "The port for the health endpoint"
     default: 14824
+
+  metron_agent.batch.interval:
+    description: "EXPERIMENTAL: Batching interval for v2 egressing"
+    default: 500000000
+  metron_agent.batch.size:
+    description: "EXPERIMENTAL: Batching size for v2 egressing"
+    default: 100

--- a/jobs/metron_agent/templates/metron_agent.json.erb
+++ b/jobs/metron_agent/templates/metron_agent.json.erb
@@ -38,7 +38,7 @@
         a[:DopplerAddr] = "#{doppler_addr}:#{p('doppler.grpc_port')}"
         a[:DopplerAddrWithAZ] = "#{doppler_addr_with_az}:#{p('doppler.grpc_port')}"
         a[:BatchSize] = p('metron_agent.batch.size')
-        a[:Interval] = p('metron_agent.batch.interval')
+        a[:BatchInterval] = p('metron_agent.batch.interval')
     end
 %>
 

--- a/jobs/metron_agent/templates/metron_agent.json.erb
+++ b/jobs/metron_agent/templates/metron_agent.json.erb
@@ -37,6 +37,8 @@
         a[:GRPC] = grpcConfig
         a[:DopplerAddr] = "#{doppler_addr}:#{p('doppler.grpc_port')}"
         a[:DopplerAddrWithAZ] = "#{doppler_addr_with_az}:#{p('doppler.grpc_port')}"
+        a[:BatchSize] = p('metron_agent.batch.size')
+        a[:Interval] = p('metron_agent.batch.interval')
     end
 %>
 

--- a/jobs/metron_agent_windows/spec
+++ b/jobs/metron_agent_windows/spec
@@ -101,3 +101,10 @@ properties:
   metron_agent.health_port:
     description: "The port for the health endpoint"
     default: 14824
+
+  metron_agent.batch.interval:
+    description: "EXPERIMENTAL: Batching interval for v2 egressing"
+    default: 500000000
+  metron_agent.batch.size:
+    description: "EXPERIMENTAL: Batching size for v2 egressing"
+    default: 100

--- a/jobs/metron_agent_windows/templates/metron_agent.json.erb
+++ b/jobs/metron_agent_windows/templates/metron_agent.json.erb
@@ -38,7 +38,7 @@
         a[:DopplerAddr] = "#{doppler_addr}:#{p('doppler.grpc_port')}"
         a[:DopplerAddrWithAZ] = "#{doppler_addr_with_az}:#{p('doppler.grpc_port')}"
         a[:BatchSize] = p('metron_agent.batch.size')
-        a[:Interval] = p('metron_agent.batch.interval')
+        a[:BatchInterval] = p('metron_agent.batch.interval')
     end
 %>
 

--- a/jobs/metron_agent_windows/templates/metron_agent.json.erb
+++ b/jobs/metron_agent_windows/templates/metron_agent.json.erb
@@ -37,6 +37,8 @@
         a[:GRPC] = grpcConfig
         a[:DopplerAddr] = "#{doppler_addr}:#{p('doppler.grpc_port')}"
         a[:DopplerAddrWithAZ] = "#{doppler_addr_with_az}:#{p('doppler.grpc_port')}"
+        a[:BatchSize] = p('metron_agent.batch.size')
+        a[:Interval] = p('metron_agent.batch.interval')
     end
 %>
 

--- a/src/code.cloudfoundry.org/loggregator/doppler/app/config.go
+++ b/src/code.cloudfoundry.org/loggregator/doppler/app/config.go
@@ -59,6 +59,11 @@ type Config struct {
 	PPROFPort                       uint32
 	HealthAddr                      string
 
+	// TODO: These should be removed once we better understand what the
+	// value should be set to.
+	BatchInterval int
+	BatchSize     uint
+
 	// TODO: Deprecated. We left this in during the removal of Dopplers
 	// outgoing websocket server. This is still needed so that
 	// trafficcontroller can find dopplers via etcd.
@@ -119,7 +124,9 @@ func ParseConfig(configFile string) (*Config, error) {
 
 func Parse(confData []byte) (*Config, error) {
 	config := &Config{
-		OutgoingPort: 8081,
+		OutgoingPort:  8081,
+		BatchSize:     100,
+		BatchInterval: int(500 * time.Millisecond),
 	}
 
 	err := json.Unmarshal(confData, config)

--- a/src/code.cloudfoundry.org/loggregator/doppler/app/doppler.go
+++ b/src/code.cloudfoundry.org/loggregator/doppler/app/doppler.go
@@ -65,6 +65,8 @@ func NewDoppler(grpc GRPC, opts ...DopplerOption) *Doppler {
 			ContainerMetricTTLSeconds:    120,
 			DisableAnnounce:              true,
 			DisableSyslogDrains:          true,
+			BatchSize:                    100,
+			BatchInterval:                int(500 * time.Millisecond),
 		},
 	}
 
@@ -193,8 +195,8 @@ func (d *Doppler) Start() {
 	v2Egress := v2.NewEgressServer(
 		v2PubSub,
 		healthRegistrar,
-		time.Second,
-		100,
+		time.Duration(d.c.BatchInterval),
+		d.c.BatchSize,
 	)
 
 	var opts []plumbing.ConfigOption

--- a/src/code.cloudfoundry.org/loggregator/metron/app/app_v2.go
+++ b/src/code.cloudfoundry.org/loggregator/metron/app/app_v2.go
@@ -97,7 +97,8 @@ func (a *AppV2) Start() {
 		envelopeBuffer,
 		counterAggr,
 		a.config.Tags,
-		100, time.Second,
+		a.config.BatchSize,
+		time.Duration(a.config.BatchInterval),
 		a.metricClient,
 	)
 	go tx.Start()

--- a/src/code.cloudfoundry.org/loggregator/metron/app/config.go
+++ b/src/code.cloudfoundry.org/loggregator/metron/app/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 type GRPC struct {
@@ -36,6 +37,11 @@ type Config struct {
 	MetricBatchIntervalMilliseconds  uint
 	RuntimeStatsIntervalMilliseconds uint
 
+	// TODO: These should be removed once we better understand what the
+	// value should be set to.
+	BatchInterval int
+	BatchSize     int
+
 	PPROFPort uint32
 }
 
@@ -53,6 +59,8 @@ func Parse(reader io.Reader) (*Config, error) {
 	config := &Config{
 		MetricBatchIntervalMilliseconds:  60000,
 		RuntimeStatsIntervalMilliseconds: 60000,
+		BatchInterval:                    int(500 * time.Millisecond),
+		BatchSize:                        100,
 	}
 	err := json.NewDecoder(reader).Decode(config)
 	if err != nil {


### PR DESCRIPTION
With batching in Metron and Doppler, a message in a low-throughput system could potentially be delivered after the combined intervals of both components.

This PR makes those intervals and batch sizes configurable, to allow operators to fine tune Loggregator to the needs of their system.

Signed-off-by: Eno Compton <ecompton@pivotal.io>

/cc @ahevenor 