### PR TITLE
Remove unused kisielk/gotool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ releases/**/*.tgz
 /src/github.com/golang/lint
 /src/github.com/opennota/check
 /src/github.com/kisielk/errcheck
+src/github.com/kisielk/gotool
 /src/github.com/gordonklaus/ineffassign
 /src/github.com/mvdan/interfacer
 /src/github.com/mvdan/lint

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,9 +40,6 @@
 [submodule "src/github.com/golang/protobuf"]
 	path = src/github.com/golang/protobuf
 	url = https://github.com/golang/protobuf
-[submodule "src/github.com/kisielk/gotool"]
-	path = src/github.com/kisielk/gotool
-	url = https://github.com/kisielk/gotool
 [submodule "src/github.com/codegangsta/cli"]
 	path = src/github.com/codegangsta/cli
 	url = https://github.com/codegangsta/cli

--- a/scripts/test
+++ b/scripts/test
@@ -64,6 +64,8 @@ function exit_on_failure {
 function run_cleaners {
     print_checkpoint "Running Cleaners"
 
+    go get github.com/kisielk/gotool
+
     if ! which goimports > /dev/null 2>&1; then
         echo installing goimports
         go get golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
Nothing in code.cloudfoundry.org/loggregator uses this package. The
release should vendor libraries used only in loggregator source.