### PR TITLE
Update TLS cert variables to contain SANs

### DIFF
--- a/manifests/loggregator.yml
+++ b/manifests/loggregator.yml
@@ -47,10 +47,10 @@ instance_groups:
         bosh_dns: true
       loggregator:
         tls:
-          ca_cert: "((loggregator_metron.ca))"
+          ca_cert: "((loggregator_agent.ca))"
           metron:
-            cert: "((loggregator_metron.certificate))"
-            key: "((loggregator_metron.private_key))"
+            cert: "((loggregator_agent.certificate))"
+            key: "((loggregator_agent.private_key))"
 
 - name: doppler
   azs:
@@ -71,10 +71,10 @@ instance_groups:
       loggregator:
         disable_syslog_drains: true
         tls:
-          ca_cert: "((loggregator_doppler.ca))"
+          ca_cert: "((loggregator_router.ca))"
           doppler:
-            cert: "((loggregator_doppler.certificate))"
-            key: "((loggregator_doppler.private_key))"
+            cert: "((loggregator_router.certificate))"
+            key: "((loggregator_router.private_key))"
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties
@@ -156,11 +156,14 @@ variables:
   options:
     common_name: loggregatorCA
     is_ca: true
-- name: loggregator_doppler
+- name: loggregator_router
   type: certificate
   options:
     ca: loggregator_ca
-    common_name: doppler
+    common_name: router
+    alternative_names:
+    - router
+    - doppler
     extended_key_usage:
     - client_auth
     - server_auth
@@ -176,15 +179,21 @@ variables:
   type: certificate
   options:
     ca: loggregator_ca
-    common_name: reverselogproxy
+    common_name: rlp
+    alternative_names:
+    - rlp
+    - reverselogproxy
     extended_key_usage:
     - client_auth
     - server_auth
-- name: loggregator_metron
+- name: loggregator_agent
   type: certificate
   options:
     ca: loggregator_ca
-    common_name: metron
+    common_name: agent
+    alternative_names:
+    - agent
+    - metron
     extended_key_usage:
     - client_auth
     - server_auth


### PR DESCRIPTION
This adds SANs for old and new names for router, agent, and rlp.

This follows the certificate generation used for container deployments:

- https://hub.docker.com/r/loggregator/certs/
- https://github.com/cloudfoundry/loggregator-ci/blob/master/docker-images/certs/generate-certs.sh

This also renames the variable names which will force the router and agent certs to be re-generated.

If this is accepted I have a PR I can submit for cf-deployment. I wanted to have the conversation here first though.