### PR TITLE
Add localhost DNS names and IP addresses as SANs for the agent

### DIFF
--- a/manifests/loggregator.yml
+++ b/manifests/loggregator.yml
@@ -185,6 +185,12 @@ variables:
   options:
     ca: loggregator_ca
     common_name: metron
+    alternative_names:
+    - metron
+    - localhost
+    - 127.0.0.1
+    - ip6-localhost
+    - ::1
     extended_key_usage:
     - client_auth
     - server_auth


### PR DESCRIPTION
This addresses the issue raised here: https://github.com/cloudfoundry/loggregator-release/issues/281

I deployed to bosh-lite and validated that it generated the correct SANs:

```
X509v3 Subject Alternative Name:
    DNS:localhost, DNS:ip6-localhost, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1
```

This has merge considerations with: https://github.com/cloudfoundry/loggregator-release/pull/350

If this is accepted I have a PR I can submit for cf-deployment.