### PR TITLE
Add a drain script for the loggregator_trafficcontroller

### DIFF
--- a/jobs/loggregator_trafficcontroller/spec
+++ b/jobs/loggregator_trafficcontroller/spec
@@ -11,6 +11,7 @@ templates:
   mutual_tls_ca.crt.erb: config/certs/mutual_tls_ca.crt
   uaa_ca.crt.erb: config/certs/uaa_ca.crt
   dns_health_check.erb: bin/dns_health_check
+  drain.erb: bin/drain
 
 packages:
 - loggregator_trafficcontroller

--- a/jobs/loggregator_trafficcontroller/templates/drain.erb
+++ b/jobs/loggregator_trafficcontroller/templates/drain.erb
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+pidfile=/var/vcap/sys/run/loggregator_trafficcontroller/loggregator_trafficcontroller.pid
+logdir=/var/vcap/sys/log/loggregator_trafficcontroller
+jobdir=/var/vcap/jobs/loggregator_trafficcontroller
+
+exec 3>&1
+
+mkdir -p "${logdir}"
+
+exec 1>> ${logdir}/drain.log
+exec 2>> ${logdir}/drain.log
+
+if [ ! -f $pidfile ]; then
+  echo "$(date): loggregator_trafficcontroller is not running"
+  echo 0 >&3
+  exit 0
+fi
+
+pid=$(cat $pidfile)
+
+if kill -0 $pid; then
+  echo "$(date): triggering drain"
+  ${jobdir}/bin/loggregator_trafficcontroller_ctl stop
+  echo 5 >&3
+else
+  echo "$(date): loggregator_trafficcontroller is not running"
+  echo 0 >&3
+  exit 0
+fi

--- a/jobs/loggregator_trafficcontroller/templates/drain.erb
+++ b/jobs/loggregator_trafficcontroller/templates/drain.erb
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-pidfile=/var/vcap/sys/run/loggregator_trafficcontroller/loggregator_trafficcontroller.pid
 logdir=/var/vcap/sys/log/loggregator_trafficcontroller
 jobdir=/var/vcap/jobs/loggregator_trafficcontroller
 
@@ -13,20 +12,8 @@ mkdir -p "${logdir}"
 exec 1>> ${logdir}/drain.log
 exec 2>> ${logdir}/drain.log
 
-if [ ! -f $pidfile ]; then
-  echo "$(date): loggregator_trafficcontroller is not running"
-  echo 0 >&3
-  exit 0
-fi
+echo "$(date): triggering drain"
 
-pid=$(cat $pidfile)
+${jobdir}/bin/loggregator_trafficcontroller_ctl stop
 
-if kill -0 $pid; then
-  echo "$(date): triggering drain"
-  ${jobdir}/bin/loggregator_trafficcontroller_ctl stop
-  echo 5 >&3
-else
-  echo "$(date): loggregator_trafficcontroller is not running"
-  echo 0 >&3
-  exit 0
-fi
+echo 5 >&3


### PR DESCRIPTION
We want to make sure the traffic controller is stopped first before any other services. We use Consul DNS for resolving the Cloud Controller API addresses, but there is no guarantee that the Consul agent is not stopped before the traffic controller service which will cause errors.

When stopping the traffic controller VM we regularly see the following error message:

```
2018/01/23 15:13:28 Could not get app information: [Get https://cloud-controller-ng.service.cf.internal:9023/internal/v4/log_access/xxx: dial tcp: lookup cloud-controller-ng.service.cf.internal on 10.0.0.2:53: no such host
```

This would solve https://github.com/cloudfoundry/loggregator-release/issues/355.