### PR TITLE
Allow for running loggregator with RLP only

### DIFF
--- a/manifests/operations/no-traffic-controller.yml
+++ b/manifests/operations/no-traffic-controller.yml
@@ -1,3 +1,3 @@
 ---
 - type: remove
-  path: /instance_groups/name=log-api?
+  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller?


### PR DESCRIPTION
This is needed in order to run acceptance tests against a deployment with no TC but with an RLP.

1. `no-traffic-controller.yml` was renamed to `no-log-api.yml` as that is what it was actually doing.
2. A new `no-traffic-controller.yml` was created that only removes the traffic controller.

I'm not certain if these ops files are used elsewhere. These changes might break things.