### PR TITLE
No TC in bosh lite script

### DIFF
--- a/manifests/operations/no-traffic-controller.yml
+++ b/manifests/operations/no-traffic-controller.yml
@@ -1,3 +1,3 @@
 ---
 - type: remove
-  path: /instance_groups/name=log-api?
+  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller?

--- a/scripts/deploy-bosh-lite
+++ b/scripts/deploy-bosh-lite
@@ -1,14 +1,14 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-set -e -x
+set -ex
 
-env_name=$1
-if [ "$env_name" == '' ]
-then
-    env_name=lite
-fi
+env_name="${1:-lite}"
 
 bosh create-release --force
-bosh -e $env_name upload-release --rebase
-bosh -e $env_name deploy -n -d loggregator manifests/loggregator.yml \
-    --vars-store=/tmp/loggregator-vars.yml
+bosh upload-release --environment="$env_name" --rebase
+bosh deploy manifests/loggregator.yml \
+    --ops-file=manifests/operations/no-traffic-controller.yml \
+    --vars-store=/tmp/loggregator-vars.yml \
+    --environment="$env_name" \
+    --deployment=loggregator \
+    --non-interactive


### PR DESCRIPTION
This allows for the following workflow for local development:

```bash
cd ~/workspace/loggregator-release
scripts/deploy-bosh-lite
cd ~/workspace/logging-acceptance-tests-release/
scripts/deploy-bosh-lite
scripts/lats
```

It represents an easy onramp for contributors.