### PR TITLE
Add profile collector

### DIFF
--- a/jobs/doppler/spec
+++ b/jobs/doppler/spec
@@ -11,6 +11,7 @@ templates:
 
 packages:
 - doppler
+- profiler
 
 provides:
 - name: doppler

--- a/jobs/doppler/templates/doppler_ctl.erb
+++ b/jobs/doppler/templates/doppler_ctl.erb
@@ -7,10 +7,7 @@
     end
 %>
 
-RUN_DIR=/var/vcap/sys/run/doppler
-LOG_DIR=/var/vcap/sys/log/doppler
-PIDFILE=$RUN_DIR/doppler.pid
-ENVIRONMENT=/var/vcap/jobs/doppler/bin/environment.sh
+source /var/vcap/jobs/doppler/bin/environment.sh
 
 mkdir -p $RUN_DIR
 mkdir -p $LOG_DIR
@@ -32,7 +29,6 @@ case $1 in
 
     chown -R vcap:vcap $LOG_DIR
 
-    source $ENVIRONMENT
     chpst -u vcap:vcap /var/vcap/packages/doppler/doppler 2>&1 | \
          tee -a "$LOG_DIR/doppler.log" | \
          logger -t "vcap.doppler" -p user.error &
@@ -51,8 +47,13 @@ case $1 in
 
     ;;
 
+  profile)
+    exec chpst -u vcap:vcap $PROFILE_EXECUTABLE
+
+    ;;
+
   *)
-    echo "Usage: doppler {start|stop}"
+    echo "Usage: doppler {start|stop|profile}"
 
     ;;
 

--- a/jobs/doppler/templates/environment.sh.erb
+++ b/jobs/doppler/templates/environment.sh.erb
@@ -1,9 +1,18 @@
+export RUN_DIR="/var/vcap/sys/run/doppler"
+export LOG_DIR="/var/vcap/sys/log/doppler"
+export PIDFILE="${RUN_DIR}/doppler.pid"
+export JOB_DIR="/var/vcap/jobs/doppler"
+export CERT_DIR="$JOB_DIR/config/certs"
+export PACKAGE_DIR="/var/vcap/packages/doppler"
+export PACKAGE_EXECUTABLE="doppler"
+export PROFILE_EXECUTABLE="/var/vcap/packages/profiler/profiler.sh"
+
 export AGENT_GRPC_ADDRESS="<%= p('metron_endpoint.host').to_s + ":" + p('metron_endpoint.grpc_port').to_s %>"
 
 export ROUTER_PORT="<%= p("doppler.grpc_port") %>"
-export ROUTER_CERT_FILE="/var/vcap/jobs/doppler/config/certs/doppler.crt"
-export ROUTER_KEY_FILE="/var/vcap/jobs/doppler/config/certs/doppler.key"
-export ROUTER_CA_FILE="/var/vcap/jobs/doppler/config/certs/loggregator_ca.crt"
+export ROUTER_CERT_FILE="$CERT_DIR/doppler.crt"
+export ROUTER_KEY_FILE="$CERT_DIR/doppler.key"
+export ROUTER_CA_FILE="$CERT_DIR/loggregator_ca.crt"
 export ROUTER_CIPHER_SUITES="<%= p("loggregator.tls.cipher_suites").split(":").join(',') %>"
 
 export ROUTER_MAX_RETAINED_LOG_MESSAGES="<%= p("doppler.maxRetainedLogMessages") %>"

--- a/jobs/loggregator_trafficcontroller/spec
+++ b/jobs/loggregator_trafficcontroller/spec
@@ -15,6 +15,7 @@ templates:
 
 packages:
 - loggregator_trafficcontroller
+- profiler
 
 provides:
 - name: trafficcontroller

--- a/jobs/loggregator_trafficcontroller/templates/environment.sh.erb
+++ b/jobs/loggregator_trafficcontroller/templates/environment.sh.erb
@@ -1,3 +1,12 @@
+export RUN_DIR="/var/vcap/sys/run/loggregator_trafficcontroller"
+export LOG_DIR="/var/vcap/sys/log/loggregator_trafficcontroller"
+export PIDFILE="$RUN_DIR/loggregator_trafficcontroller.pid"
+export JOB_DIR="/var/vcap/jobs/loggregator_trafficcontroller"
+export CERT_DIR="$JOB_DIR/config/certs"
+export PACKAGE_DIR="/var/vcap/packages/loggregator_trafficcontroller"
+export PACKAGE_EXECUTABLE="trafficcontroller"
+export PROFILE_EXECUTABLE="/var/vcap/packages/profiler/profiler.sh"
+
 <%
     router_addrs = []
 
@@ -17,17 +26,18 @@
 
     uaa_host = p("uaa.internal_url")
 %>
+
 export AGENT_UDP_ADDRESS="<%= p('metron_endpoint.host').to_s + ":" + p('metron_endpoint.dropsonde_port').to_s %>"
 export AGENT_GRPC_ADDRESS="<%= p('metron_endpoint.host').to_s + ":" + p('metron_endpoint.grpc_port').to_s %>"
 
 export ROUTER_ADDRS="<%= router_addrs.join(",") %>"
-export ROUTER_CA_FILE="/var/vcap/jobs/loggregator_trafficcontroller/config/certs/loggregator_ca.crt"
-export ROUTER_CERT_FILE="/var/vcap/jobs/loggregator_trafficcontroller/config/certs/trafficcontroller.crt"
-export ROUTER_KEY_FILE="/var/vcap/jobs/loggregator_trafficcontroller/config/certs/trafficcontroller.key"
+export ROUTER_CA_FILE="$CERT_DIR/loggregator_ca.crt"
+export ROUTER_CERT_FILE="$CERT_DIR/trafficcontroller.crt"
+export ROUTER_KEY_FILE="$CERT_DIR/trafficcontroller.key"
 
-export CC_CERT_FILE="/var/vcap/jobs/loggregator_trafficcontroller/config/certs/cc_trafficcontroller.crt"
-export CC_KEY_FILE="/var/vcap/jobs/loggregator_trafficcontroller/config/certs/cc_trafficcontroller.key"
-export CC_CA_FILE="/var/vcap/jobs/loggregator_trafficcontroller/config/certs/mutual_tls_ca.crt"
+export CC_CERT_FILE="$CERT_DIR/cc_trafficcontroller.crt"
+export CC_KEY_FILE="$CERT_DIR/cc_trafficcontroller.key"
+export CC_CA_FILE="$CERT_DIR/mutual_tls_ca.crt"
 export CC_SERVER_NAME="<%= p('cc.internal_service_hostname') %>"
 
 export TRAFFIC_CONTROLLER_IP="<%= spec.ip %>"
@@ -44,7 +54,7 @@ export TRAFFIC_CONTROLLER_HEALTH_ADDR="<%= p('traffic_controller.health_addr') %
 export TRAFFIC_CONTROLLER_DISABLE_ACCESS_CONTROL="<%= p("traffic_controller.disable_access_control") %>"
 
 <% if !uaa_host.empty? %>
-export TRAFFIC_CONTROLLER_UAA_CA_CERT="/var/vcap/jobs/loggregator_trafficcontroller/config/certs/uaa_ca.crt"
+export TRAFFIC_CONTROLLER_UAA_CA_CERT="$CERT_DIR/uaa_ca.crt"
 <% end %>
 
 <% if p("traffic_controller.security_event_logging.enabled") %>

--- a/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller_ctl.erb
+++ b/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller_ctl.erb
@@ -7,10 +7,7 @@
     end
 %>
 
-RUN_DIR=/var/vcap/sys/run/loggregator_trafficcontroller
-LOG_DIR=/var/vcap/sys/log/loggregator_trafficcontroller
-PIDFILE=$RUN_DIR/loggregator_trafficcontroller.pid
-ENVIRONMENT=/var/vcap/jobs/loggregator_trafficcontroller/bin/environment.sh
+source /var/vcap/jobs/loggregator_trafficcontroller/bin/environment.sh
 
 mkdir -p $RUN_DIR
 mkdir -p $LOG_DIR
@@ -35,8 +32,7 @@ case $1 in
 
     chown -R vcap:vcap $LOG_DIR
 
-    source $ENVIRONMENT
-    chpst -u vcap:vcap /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller 2>&1 | \
+    chpst -u vcap:vcap $PACKAGE_DIR/$PACKAGE_EXECUTABLE 2>&1 | \
          tee -a "$LOG_DIR/trafficcontroller.log" | \
          logger -t "vcap.trafficcontroller" -p user.error &
 
@@ -56,8 +52,13 @@ case $1 in
 
     ;;
 
+  profile)
+    exec chpst -u vcap:vcap $PROFILE_EXECUTABLE
+
+    ;;
+
   *)
-    echo "Usage: loggregator_trafficcontroller {start|stop}"
+    echo "Usage: loggregator_trafficcontroller_ctl {start|stop|profile}"
 
     ;;
 

--- a/jobs/reverse_log_proxy/spec
+++ b/jobs/reverse_log_proxy/spec
@@ -11,6 +11,7 @@ templates:
 
 packages:
 - reverse_log_proxy
+- profiler
 
 consumes:
 - name: doppler

--- a/jobs/reverse_log_proxy/templates/environment.sh.erb
+++ b/jobs/reverse_log_proxy/templates/environment.sh.erb
@@ -1,3 +1,12 @@
+export RUN_DIR="/var/vcap/sys/run/reverse_log_proxy"
+export LOG_DIR="/var/vcap/sys/log/reverse_log_proxy"
+export PIDFILE="${RUN_DIR}/reverse_log_proxy.pid"
+export JOB_DIR="/var/vcap/jobs/reverse_log_proxy"
+export CERT_DIR="$JOB_DIR/config/certs"
+export PACKAGE_DIR="/var/vcap/packages/reverse_log_proxy"
+export PACKAGE_EXECUTABLE="rlp"
+export PROFILE_EXECUTABLE="/var/vcap/packages/profiler/profiler.sh"
+
 <%
     ingress_addrs = []
     if_link("doppler") { |ds|
@@ -10,16 +19,16 @@
         end
     }
 %>
+
 export RLP_PORT="<%= p('reverse_log_proxy.egress.port') %>"
 export MAX_EGRESS_STREAMS="<%= p('reverse_log_proxy.egress.max_streams') %>"
-export RLP_CERT_FILE="/var/vcap/jobs/reverse_log_proxy/config/certs/reverse_log_proxy.crt"
-export RLP_KEY_FILE="/var/vcap/jobs/reverse_log_proxy/config/certs/reverse_log_proxy.key"
-export RLP_CA_FILE="/var/vcap/jobs/reverse_log_proxy/config/certs/mutual_tls_ca.crt"
+export RLP_CERT_FILE="$CERT_DIR/reverse_log_proxy.crt"
+export RLP_KEY_FILE="$CERT_DIR/reverse_log_proxy.key"
+export RLP_CA_FILE="$CERT_DIR/mutual_tls_ca.crt"
 export RLP_CIPHER_SUITES="<%= p('loggregator.tls.cipher_suites').gsub(":", ",") %>"
 export RLP_PPROF_PORT="<%= p('reverse_log_proxy.pprof.port') %>"
 export RLP_HEALTH_ADDR="<%= p('reverse_log_proxy.health_addr') %>"
 export RLP_METRIC_EMITTER_INTERVAL="<%= p('metric_emitter.interval') %>"
 
 export ROUTER_ADDRS="<%= ingress_addrs.join(",") %>"
-
 export AGENT_ADDR="<%= "#{p('metron_endpoint.host')}:#{p('metron_endpoint.grpc_port')}" %>"

--- a/jobs/reverse_log_proxy/templates/reverse_log_proxy_ctl.erb
+++ b/jobs/reverse_log_proxy/templates/reverse_log_proxy_ctl.erb
@@ -1,22 +1,15 @@
 #!/bin/bash -e
 
-RUN_DIR=/var/vcap/sys/run/reverse_log_proxy
-LOG_DIR=/var/vcap/sys/log/reverse_log_proxy
-PIDFILE=${RUN_DIR}/reverse_log_proxy.pid
-JOB_DIR=/var/vcap/jobs/reverse_log_proxy
-CERT_DIR=$JOB_DIR/config/certs
-
-PACKAGE_DIR=/var/vcap/packages/reverse_log_proxy
-ENVIRONMENT=/var/vcap/jobs/reverse_log_proxy/bin/environment.sh
+source /var/vcap/jobs/reverse_log_proxy/bin/environment.sh
 
 case $1 in
 
   start)
     set +e
-      killall -15 rlp
-      killall -9 rlp
-      killall -2 rlp
-      killall -3 rlp
+      killall -15 $PACKAGE_EXECUTABLE
+      killall -9 $PACKAGE_EXECUTABLE
+      killall -2 $PACKAGE_EXECUTABLE
+      killall -3 $PACKAGE_EXECUTABLE
     set -e
 
     mkdir -p $RUN_DIR $LOG_DIR
@@ -26,26 +19,30 @@ case $1 in
 
     ulimit -n 8192
 
-    source $ENVIRONMENT
     echo $$ > $PIDFILE
-    exec chpst -u vcap:vcap ./rlp &>> ${LOG_DIR}/rlp.log
+    exec chpst -u vcap:vcap ./$PACKAGE_EXECUTABLE &>> ${LOG_DIR}/$PACKAGE_EXECUTABLE.log
 
     ;;
 
   stop)
     set +e
-      killall -15 rlp
-      killall -9 rlp
-      killall -2 rlp
-      killall -3 rlp
+      killall -15 $PACKAGE_EXECUTABLE
+      killall -9 $PACKAGE_EXECUTABLE
+      killall -2 $PACKAGE_EXECUTABLE
+      killall -3 $PACKAGE_EXECUTABLE
     set -e
 
     rm -f $PIDFILE
 
     ;;
 
+  profile)
+    exec chpst -u vcap:vcap $PROFILE_EXECUTABLE
+
+    ;;
+
   *)
-    echo "Usage: reverse_log_proxy_ctl {start|stop}"
+    echo "Usage: reverse_log_proxy_ctl {start|stop|profile}"
 
     ;;
 

--- a/jobs/reverse_log_proxy_gateway/spec
+++ b/jobs/reverse_log_proxy_gateway/spec
@@ -11,6 +11,7 @@ templates:
 
 packages:
 - reverse_log_proxy_gateway
+- profiler
 
 consumes:
 - name: reverse_log_proxy

--- a/jobs/reverse_log_proxy_gateway/templates/environment.sh.erb
+++ b/jobs/reverse_log_proxy_gateway/templates/environment.sh.erb
@@ -1,6 +1,15 @@
+export RUN_DIR=/var/vcap/sys/run/reverse_log_proxy_gateway
+export LOG_DIR=/var/vcap/sys/log/reverse_log_proxy_gateway
+export PIDFILE=${RUN_DIR}/reverse_log_proxy_gateway.pid
+export JOB_DIR=/var/vcap/jobs/reverse_log_proxy_gateway
+export CERT_DIR=$JOB_DIR/config/certs
+export PACKAGE_DIR=/var/vcap/packages/reverse_log_proxy_gateway
+export PACKAGE_EXECUTABLE="rlp-gateway"
+export PROFILE_EXECUTABLE="/var/vcap/packages/profiler/profiler.sh"
+
 export LOGS_PROVIDER_ADDR="127.0.0.1:<%= link('reverse_log_proxy').p('reverse_log_proxy.egress.port') %>"
-export LOGS_PROVIDER_CLIENT_CERT_PATH="/var/vcap/jobs/reverse_log_proxy_gateway/config/certs/reverse_log_proxy_gateway.crt"
-export LOGS_PROVIDER_CLIENT_KEY_PATH="/var/vcap/jobs/reverse_log_proxy_gateway/config/certs/reverse_log_proxy_gateway.key"
-export LOGS_PROVIDER_CA_PATH="/var/vcap/jobs/reverse_log_proxy_gateway/config/certs/mutual_tls_ca.crt"
+export LOGS_PROVIDER_CLIENT_CERT_PATH="$CERT_DIR/reverse_log_proxy_gateway.crt"
+export LOGS_PROVIDER_CLIENT_KEY_PATH="$CERT_DIR/reverse_log_proxy_gateway.key"
+export LOGS_PROVIDER_CA_PATH="$CERT_DIR/mutual_tls_ca.crt"
 export LOGS_PROVIDER_COMMON_NAME="<%= p('logs_provider.common_name') %>"
 export GATEWAY_ADDR="<%= p('http.address') %>"

--- a/jobs/reverse_log_proxy_gateway/templates/reverse_log_proxy_gateway_ctl.erb
+++ b/jobs/reverse_log_proxy_gateway/templates/reverse_log_proxy_gateway_ctl.erb
@@ -1,13 +1,6 @@
 #!/bin/bash -e
 
-RUN_DIR=/var/vcap/sys/run/reverse_log_proxy_gateway
-LOG_DIR=/var/vcap/sys/log/reverse_log_proxy_gateway
-PIDFILE=${RUN_DIR}/reverse_log_proxy_gateway.pid
-JOB_DIR=/var/vcap/jobs/reverse_log_proxy_gateway
-CERT_DIR=$JOB_DIR/config/certs
-
-PACKAGE_DIR=/var/vcap/packages/reverse_log_proxy_gateway
-ENVIRONMENT=/var/vcap/jobs/reverse_log_proxy_gateway/bin/environment.sh
+source /var/vcap/jobs/reverse_log_proxy_gateway/bin/environment.sh
 
 case $1 in
 
@@ -26,7 +19,6 @@ case $1 in
 
     ulimit -n 8192
 
-    source $ENVIRONMENT
     echo $$ > $PIDFILE
     exec chpst -u vcap:vcap ./rlp-gateway &>> ${LOG_DIR}/rlp-gateway.log
 
@@ -44,8 +36,13 @@ case $1 in
 
     ;;
 
+  profile)
+    exec chpst -u vcap:vcap $PROFILE_EXECUTABLE
+
+    ;;
+
   *)
-    echo "Usage: reverse_log_proxy_gateway_ctl {start|stop}"
+    echo "Usage: reverse_log_proxy_gateway_ctl {start|stop|profile}"
 
     ;;
 

--- a/jobs/reverse_log_proxy_gateway_cf_auth_proxy/spec
+++ b/jobs/reverse_log_proxy_gateway_cf_auth_proxy/spec
@@ -10,6 +10,7 @@ templates:
 
 packages:
 - reverse_log_proxy_gateway_cf_auth_proxy
+- profiler
 
 provides:
 - name: log_gateway_cf_auth_proxy
@@ -45,4 +46,3 @@ properties:
     description: "The CA for internal UAA api"
   uaa.internal_addr:
     description: "The endpoint used for the internal UAA api"
-

--- a/jobs/reverse_log_proxy_gateway_cf_auth_proxy/templates/ctl
+++ b/jobs/reverse_log_proxy_gateway_cf_auth_proxy/templates/ctl
@@ -1,13 +1,6 @@
 #!/bin/bash -e
 
-RUN_DIR=/var/vcap/sys/run/reverse_log_proxy_gateway_cf_auth_proxy
-LOG_DIR=/var/vcap/sys/log/reverse_log_proxy_gateway_cf_auth_proxy
-PIDFILE=${RUN_DIR}/reverse_log_proxy_gateway_cf_auth_proxy.pid
-JOB_DIR=/var/vcap/jobs/reverse_log_proxy_gateway_cf_auth_proxy
-CERT_DIR=$JOB_DIR/config/certs
-
-PACKAGE_DIR=/var/vcap/packages/reverse_log_proxy_gateway_cf_auth_proxy
-ENVIRONMENT=/var/vcap/jobs/reverse_log_proxy_gateway_cf_auth_proxy/bin/environment.sh
+source /var/vcap/jobs/reverse_log_proxy_gateway_cf_auth_proxy/bin/environment.sh
 
 case $1 in
 
@@ -26,7 +19,6 @@ case $1 in
 
     ulimit -n 8192
 
-    source $ENVIRONMENT
     echo $$ > $PIDFILE
     exec chpst -u vcap:vcap ./rlp-gateway-cf-auth-proxy &>> ${LOG_DIR}/rlp-gateway-cf-auth-proxy.log
 
@@ -44,8 +36,13 @@ case $1 in
 
     ;;
 
+  profile)
+    exec chpst -u vcap:vcap $PROFILE_EXECUTABLE
+
+    ;;
+
   *)
-    echo "Usage: ctl {start|stop}"
+    echo "Usage: ctl {start|stop|profile}"
 
     ;;
 

--- a/jobs/reverse_log_proxy_gateway_cf_auth_proxy/templates/environment.sh.erb
+++ b/jobs/reverse_log_proxy_gateway_cf_auth_proxy/templates/environment.sh.erb
@@ -1,3 +1,14 @@
+#!/bin/bash -e
+
+RUN_DIR=/var/vcap/sys/run/reverse_log_proxy_gateway_cf_auth_proxy
+LOG_DIR=/var/vcap/sys/log/reverse_log_proxy_gateway_cf_auth_proxy
+PIDFILE=${RUN_DIR}/reverse_log_proxy_gateway_cf_auth_proxy.pid
+JOB_DIR=/var/vcap/jobs/reverse_log_proxy_gateway_cf_auth_proxy
+CERT_DIR=$JOB_DIR/config/certs
+PACKAGE_DIR=/var/vcap/packages/reverse_log_proxy_gateway_cf_auth_proxy
+export PACKAGE_EXECUTABLE="rlp-gateway-cf-auth-proxy"
+export PROFILE_EXECUTABLE="/var/vcap/packages/profiler/profiler.sh"
+
 <%
     log_gateway = link('log_gateway')
     cc = link('cloud_controller')
@@ -7,9 +18,9 @@
 # termination.
 export CAPI_ADDR_EXTERNAL="<%= "http://#{cc.address}:9022" %>"
 export CAPI_ADDR="<%= "https://#{cc.address}:9023" %>"
-export CAPI_CERT_PATH="/var/vcap/jobs/reverse_log_proxy_gateway_cf_auth_proxy/config/certs/cc.crt"
-export CAPI_KEY_PATH="/var/vcap/jobs/reverse_log_proxy_gateway_cf_auth_proxy/config/certs/cc.key"
-export CAPI_CA_PATH="/var/vcap/jobs/reverse_log_proxy_gateway_cf_auth_proxy/config/certs/cc_ca.crt"
+export CAPI_CERT_PATH="$CERT_DIR/cc.crt"
+export CAPI_KEY_PATH="$CERT_DIR/cc.key"
+export CAPI_CA_PATH="$CERT_DIR/cc_ca.crt"
 export CAPI_COMMON_NAME="<%= p('cc.common_name') %>"
 
 export UAA_CLIENT_ID="<%= p('uaa.client_id') %>"

--- a/packages/profiler/packaging
+++ b/packages/profiler/packaging
@@ -1,0 +1,4 @@
+set -e
+
+cp profiler.sh "${BOSH_INSTALL_TARGET}"
+chmod +x "${BOSH_INSTALL_TARGET}/profiler.sh"

--- a/packages/profiler/spec
+++ b/packages/profiler/spec
@@ -1,0 +1,7 @@
+---
+name: profiler
+
+dependencies: []
+
+files:
+- profiler.sh

--- a/spec/doppler/templates/environment.sh.erb_spec.rb
+++ b/spec/doppler/templates/environment.sh.erb_spec.rb
@@ -37,11 +37,19 @@ RSpec.describe "Doppler Environment" do
     )
 
     expected_config = {
+      "CERT_DIR" => "$JOB_DIR/config/certs",
+      "JOB_DIR" => "/var/vcap/jobs/doppler",
+      "LOG_DIR" => "/var/vcap/sys/log/doppler",
+      "PACKAGE_DIR" => "/var/vcap/packages/doppler",
+      "PACKAGE_EXECUTABLE" => "doppler",
+      "PIDFILE" => "${RUN_DIR}/doppler.pid",
+      "PROFILE_EXECUTABLE" => "/var/vcap/packages/profiler/profiler.sh",
+      "RUN_DIR" => "/var/vcap/sys/run/doppler",
       "AGENT_GRPC_ADDRESS" => "10.0.0.10:5555",
       "ROUTER_PORT" => "1111",
-      "ROUTER_CERT_FILE" => "/var/vcap/jobs/doppler/config/certs/doppler.crt",
-      "ROUTER_KEY_FILE" => "/var/vcap/jobs/doppler/config/certs/doppler.key",
-      "ROUTER_CA_FILE" => "/var/vcap/jobs/doppler/config/certs/loggregator_ca.crt",
+      "ROUTER_CERT_FILE" => "$CERT_DIR/doppler.crt",
+      "ROUTER_KEY_FILE" => "$CERT_DIR/doppler.key",
+      "ROUTER_CA_FILE" => "$CERT_DIR/loggregator_ca.crt",
       "ROUTER_CIPHER_SUITES" => "a,b",
       "ROUTER_MAX_RETAINED_LOG_MESSAGES" => "100",
       "ROUTER_CONTAINER_METRIC_TTL_SECONDS" => "60",

--- a/spec/loggregator_trafficcontroller/templates/environment.sh.erb_spec.rb
+++ b/spec/loggregator_trafficcontroller/templates/environment.sh.erb_spec.rb
@@ -1,189 +1,197 @@
-require "spec_helper"
+require 'spec_helper'
 
-RSpec.describe "Traffic Controller Environment" do
-  it "renders a full environment" do
+RSpec.describe 'Traffic Controller Environment' do
+  it 'renders a full environment' do
     properties = {
-      "cc" => {
-        "internal_service_hostname" => "cc.service.cf.internal",
-        "tls_port" => 8888,
+      'cc' => {
+        'internal_service_hostname' => 'cc.service.cf.internal',
+        'tls_port' => 8888
       },
-      "doppler" => {
-        "grpc_port" => 1111,
-        "outgoing_port" => 4444,
+      'doppler' => {
+        'grpc_port' => 1111,
+        'outgoing_port' => 4444
       },
-      "loggregator" => {
-        "doppler" => {
-          "addrs" => ["doppler.service.cf.internal"]
+      'loggregator' => {
+        'doppler' => {
+          'addrs' => ['doppler.service.cf.internal']
         },
-        "outgoing_dropsonde_port" => 5555,
-        "uaa" => {
-          "client" => "some-client",
-          "client_secret" => "some-secret"
+        'outgoing_dropsonde_port' => 5555,
+        'uaa' => {
+          'client' => 'some-client',
+          'client_secret' => 'some-secret'
         }
       },
-      "metric_emitter" => {
-        "interval" => "1m",
+      'metric_emitter' => {
+        'interval' => '1m'
       },
-      "metron_endpoint" => {
-        "dropsonde_port" => 2222,
-        "grpc_port" => 3333,
-        "host" => "10.0.0.1",
+      'metron_endpoint' => {
+        'dropsonde_port' => 2222,
+        'grpc_port' => 3333,
+        'host' => '10.0.0.1'
       },
-      "ssl" => {
-        "skip_cert_verify" => false,
+      'ssl' => {
+        'skip_cert_verify' => false
       },
-      "system_domain" => "bosh-lite.com",
-      "traffic_controller" => {
-        "disable_access_control" => true,
-        "pprof_port" => 6666,
-        "health_addr" => "localhost:7777",
-        "security_event_logging" => {
-          "enabled" => true,
+      'system_domain' => 'bosh-lite.com',
+      'traffic_controller' => {
+        'disable_access_control' => true,
+        'pprof_port' => 6666,
+        'health_addr' => 'localhost:7777',
+        'security_event_logging' => {
+          'enabled' => true
         }
       },
-      "uaa" => {
-        "internal_url" => "uaa.service.cf.internal"
+      'uaa' => {
+        'internal_url' => 'uaa.service.cf.internal'
       }
     }
-    spec = InstanceSpec.new(ip: "10.0.0.250")
+    spec = InstanceSpec.new(ip: '10.0.0.250')
     config = render_template(
       properties,
       spec: spec,
-      job: "loggregator_trafficcontroller",
-      template: "bin/environment.sh"
+      job: 'loggregator_trafficcontroller',
+      template: 'bin/environment.sh'
     )
 
     expected_config = {
-      "AGENT_UDP_ADDRESS" => "10.0.0.1:2222",
-      "AGENT_GRPC_ADDRESS" => "10.0.0.1:3333",
-      "ROUTER_ADDRS" => "doppler.service.cf.internal:1111",
-      "ROUTER_CA_FILE" => "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/loggregator_ca.crt",
-      "ROUTER_CERT_FILE" => "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/trafficcontroller.crt",
-      "ROUTER_KEY_FILE" => "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/trafficcontroller.key",
-      "CC_CERT_FILE" => "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/cc_trafficcontroller.crt",
-      "CC_KEY_FILE" => "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/cc_trafficcontroller.key",
-      "CC_CA_FILE" => "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/mutual_tls_ca.crt",
-      "CC_SERVER_NAME" => "cc.service.cf.internal",
-      "TRAFFIC_CONTROLLER_IP" => "10.0.0.250",
-      "TRAFFIC_CONTROLLER_API_HOST" => "https://cc.service.cf.internal:8888",
-      "TRAFFIC_CONTROLLER_OUTGOING_DROPSONDE_PORT" => "5555",
-      "TRAFFIC_CONTROLLER_SYSTEM_DOMAIN" => "bosh-lite.com",
-      "TRAFFIC_CONTROLLER_SKIP_CERT_VERIFY" => "false",
-      "TRAFFIC_CONTROLLER_UAA_HOST" => "uaa.service.cf.internal",
-      "TRAFFIC_CONTROLLER_UAA_CLIENT" => "some-client",
-      "TRAFFIC_CONTROLLER_UAA_CLIENT_SECRET" => "'some-secret'",
-      "TRAFFIC_CONTROLLER_UAA_CA_CERT" => "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/uaa_ca.crt",
-      "TRAFFIC_CONTROLLER_SECURITY_EVENT_LOG" => "/var/vcap/sys/log/loggregator_trafficcontroller/loggregator_trafficcontroller_security_events.log",
-      "TRAFFIC_CONTROLLER_PPROF_PORT" => "6666",
-      "TRAFFIC_CONTROLLER_METRIC_EMITTER_INTERVAL" => "1m",
-      "TRAFFIC_CONTROLLER_HEALTH_ADDR" => "localhost:7777",
-      "TRAFFIC_CONTROLLER_DISABLE_ACCESS_CONTROL" => "true",
+      'CERT_DIR' => '$JOB_DIR/config/certs',
+      'JOB_DIR' => '/var/vcap/jobs/loggregator_trafficcontroller',
+      'LOG_DIR' => '/var/vcap/sys/log/loggregator_trafficcontroller',
+      'PACKAGE_DIR' => '/var/vcap/packages/loggregator_trafficcontroller',
+      'PACKAGE_EXECUTABLE' => 'trafficcontroller',
+      'PIDFILE' => '$RUN_DIR/loggregator_trafficcontroller.pid',
+      'PROFILE_EXECUTABLE' => '/var/vcap/packages/profiler/profiler.sh',
+      'RUN_DIR' => '/var/vcap/sys/run/loggregator_trafficcontroller',
+      'AGENT_UDP_ADDRESS' => '10.0.0.1:2222',
+      'AGENT_GRPC_ADDRESS' => '10.0.0.1:3333',
+      'ROUTER_ADDRS' => 'doppler.service.cf.internal:1111',
+      'ROUTER_CA_FILE' => '$CERT_DIR/loggregator_ca.crt',
+      'ROUTER_CERT_FILE' => '$CERT_DIR/trafficcontroller.crt',
+      'ROUTER_KEY_FILE' => '$CERT_DIR/trafficcontroller.key',
+      'CC_CERT_FILE' => '$CERT_DIR/cc_trafficcontroller.crt',
+      'CC_KEY_FILE' => '$CERT_DIR/cc_trafficcontroller.key',
+      'CC_CA_FILE' => '$CERT_DIR/mutual_tls_ca.crt',
+      'CC_SERVER_NAME' => 'cc.service.cf.internal',
+      'TRAFFIC_CONTROLLER_IP' => '10.0.0.250',
+      'TRAFFIC_CONTROLLER_API_HOST' => 'https://cc.service.cf.internal:8888',
+      'TRAFFIC_CONTROLLER_OUTGOING_DROPSONDE_PORT' => '5555',
+      'TRAFFIC_CONTROLLER_SYSTEM_DOMAIN' => 'bosh-lite.com',
+      'TRAFFIC_CONTROLLER_SKIP_CERT_VERIFY' => 'false',
+      'TRAFFIC_CONTROLLER_UAA_HOST' => 'uaa.service.cf.internal',
+      'TRAFFIC_CONTROLLER_UAA_CLIENT' => 'some-client',
+      'TRAFFIC_CONTROLLER_UAA_CLIENT_SECRET' => "'some-secret'",
+      'TRAFFIC_CONTROLLER_UAA_CA_CERT' => '$CERT_DIR/uaa_ca.crt',
+      'TRAFFIC_CONTROLLER_SECURITY_EVENT_LOG' => '/var/vcap/sys/log/loggregator_trafficcontroller/loggregator_trafficcontroller_security_events.log',
+      'TRAFFIC_CONTROLLER_PPROF_PORT' => '6666',
+      'TRAFFIC_CONTROLLER_METRIC_EMITTER_INTERVAL' => '1m',
+      'TRAFFIC_CONTROLLER_HEALTH_ADDR' => 'localhost:7777',
+      'TRAFFIC_CONTROLLER_DISABLE_ACCESS_CONTROL' => 'true'
     }
     expect(config).to eq(expected_config)
   end
 
-  describe "Router configuration" do
-    it "consumes a Doppler link" do
+  describe 'Router configuration' do
+    it 'consumes a Doppler link' do
       links = [Link.new(
-        name: "doppler",
+        name: 'doppler',
         instances: [
-          LinkInstance.new(address: "doppler-1.service.cf.internal"),
-          LinkInstance.new(address: "doppler-2.service.cf.internal"),
+          LinkInstance.new(address: 'doppler-1.service.cf.internal'),
+          LinkInstance.new(address: 'doppler-2.service.cf.internal')
         ],
         properties: {
-          "doppler" => {
-            "grpc_port" => 1111,
+          'doppler' => {
+            'grpc_port' => 1111
           }
         }
       )]
       config = render_template(
         required_properties,
         links: links,
-        job: "loggregator_trafficcontroller",
-        template: "bin/environment.sh"
+        job: 'loggregator_trafficcontroller',
+        template: 'bin/environment.sh'
       )
 
-      expect(config["ROUTER_ADDRS"]).to eq("doppler-1.service.cf.internal:1111,doppler-2.service.cf.internal:1111")
+      expect(config['ROUTER_ADDRS']).to eq('doppler-1.service.cf.internal:1111,doppler-2.service.cf.internal:1111')
     end
 
-    it "uses an address property when no link is present" do
+    it 'uses an address property when no link is present' do
       properties = {
-        "doppler" => {
-          "grpc_port" => 1111,
+        'doppler' => {
+          'grpc_port' => 1111
         },
-        "loggregator" => {
-          "doppler" => {
-            "addrs" => ["10.0.0.1"],
+        'loggregator' => {
+          'doppler' => {
+            'addrs' => ['10.0.0.1']
           },
           # required property of no importance here
-          "uaa" => {
-            "client_secret" => "secret"
+          'uaa' => {
+            'client_secret' => 'secret'
           }
         }
       }
       config = render_template(
         required_properties.merge(properties),
-        job: "loggregator_trafficcontroller",
-        template: "bin/environment.sh"
+        job: 'loggregator_trafficcontroller',
+        template: 'bin/environment.sh'
       )
 
-      expect(config["ROUTER_ADDRS"]).to eq("10.0.0.1:1111")
+      expect(config['ROUTER_ADDRS']).to eq('10.0.0.1:1111')
     end
   end
 
-  describe "UAA config" do
-    it "configures a client" do
+  describe 'UAA config' do
+    it 'configures a client' do
       properties = {
-        "loggregator" => {
-          "uaa" => {
-            "client" => "some-client",
-            "client_secret" => "some-secret"
+        'loggregator' => {
+          'uaa' => {
+            'client' => 'some-client',
+            'client_secret' => 'some-secret'
           }
         }
       }
       config = render_template(
         required_properties.merge(properties),
-        job: "loggregator_trafficcontroller",
-        template: "bin/environment.sh"
+        job: 'loggregator_trafficcontroller',
+        template: 'bin/environment.sh'
       )
 
-      expect(config["TRAFFIC_CONTROLLER_UAA_CLIENT"]).to eq("some-client")
-      expect(config["TRAFFIC_CONTROLLER_UAA_CLIENT_SECRET"]).to eq("'some-secret'")
-      expect(config["TRAFFIC_CONTROLLER_UAA_CA_CERT"]).to be_nil
+      expect(config['TRAFFIC_CONTROLLER_UAA_CLIENT']).to eq('some-client')
+      expect(config['TRAFFIC_CONTROLLER_UAA_CLIENT_SECRET']).to eq("'some-secret'")
+      expect(config['TRAFFIC_CONTROLLER_UAA_CA_CERT']).to be_nil
     end
 
-    it "configures a client using an old property name" do
+    it 'configures a client using an old property name' do
       properties = {
-        "loggregator" => {
-          "uaa_client_id" => "old-name",
-          "uaa" => {
-            "client" => "some-client",
-            "client_secret" => "some-secret"
+        'loggregator' => {
+          'uaa_client_id' => 'old-name',
+          'uaa' => {
+            'client' => 'some-client',
+            'client_secret' => 'some-secret'
           }
         }
       }
       config = render_template(
         required_properties.merge(properties),
-        job: "loggregator_trafficcontroller",
-        template: "bin/environment.sh"
+        job: 'loggregator_trafficcontroller',
+        template: 'bin/environment.sh'
       )
 
-      expect(config["TRAFFIC_CONTROLLER_UAA_CLIENT"]).to eq("old-name")
+      expect(config['TRAFFIC_CONTROLLER_UAA_CLIENT']).to eq('old-name')
     end
 
-    it "adds a CA cert when the host is present" do
+    it 'adds a CA cert when the host is present' do
       properties = {
-        "uaa" => {
-          "internal_url" => "uaa.cf.service.internal"
+        'uaa' => {
+          'internal_url' => 'uaa.cf.service.internal'
         }
       }
       config = render_template(
         required_properties.merge(properties),
-        job: "loggregator_trafficcontroller",
-        template: "bin/environment.sh"
+        job: 'loggregator_trafficcontroller',
+        template: 'bin/environment.sh'
       )
 
-      expect(config["TRAFFIC_CONTROLLER_UAA_CA_CERT"]).to eq("/var/vcap/jobs/loggregator_trafficcontroller/config/certs/uaa_ca.crt")
+      expect(config['TRAFFIC_CONTROLLER_UAA_CA_CERT']).to eq('$CERT_DIR/uaa_ca.crt')
     end
   end
 
@@ -191,15 +199,15 @@ RSpec.describe "Traffic Controller Environment" do
   # provide. The values are of no interest in the tests.
   def required_properties
     {
-      "cc" => {
-        "internal_service_hostname" => "cc.service.cf.internal"
+      'cc' => {
+        'internal_service_hostname' => 'cc.service.cf.internal'
       },
-      "loggregator" => {
-        "uaa" => {
-          "client_secret" => "secret"
+      'loggregator' => {
+        'uaa' => {
+          'client_secret' => 'secret'
         }
       },
-      "system_domain" => "bosh-lite.com",
+      'system_domain' => 'bosh-lite.com'
     }
   end
 end

--- a/spec/reverse_log_proxy/templates/environment.sh.erb_spec.rb
+++ b/spec/reverse_log_proxy/templates/environment.sh.erb_spec.rb
@@ -1,84 +1,92 @@
-require "spec_helper"
+require 'spec_helper'
 
-RSpec.describe "Reverse Log Proxy Environment" do
-  it "renders a full environment" do
+RSpec.describe 'Reverse Log Proxy Environment' do
+  it 'renders a full environment' do
     properties = {
-      "reverse_log_proxy" => {
-        "egress" => {
-          "port" => "1111",
-          "max_streams" => "1000",
+      'reverse_log_proxy' => {
+        'egress' => {
+          'port' => '1111',
+          'max_streams' => '1000'
         },
-        "pprof" => {
-          "port" => "2222",
+        'pprof' => {
+          'port' => '2222'
         },
-        "health_addr" => "localhost:3333",
+        'health_addr' => 'localhost:3333'
       },
-      "loggregator" => {
-        "tls" => {
-          "reverse_log_proxy" => {
-            "key" => "/var/vcap/jobs/reverse_log_proxy/config/certs/reverse_log_proxy.key",
-            "cert" => "/var/vcap/jobs/reverse_log_proxy/config/certs/reverse_log_proxy.crt",
+      'loggregator' => {
+        'tls' => {
+          'reverse_log_proxy' => {
+            'key' => '/var/vcap/jobs/reverse_log_proxy/config/certs/reverse_log_proxy.key',
+            'cert' => '/var/vcap/jobs/reverse_log_proxy/config/certs/reverse_log_proxy.crt'
           },
-          "ca_cert" => "/var/vcap/jobs/reverse_log_proxy/config/certs/mutual_tls_ca.crt",
-          "cipher_suites" => "a:b",
+          'ca_cert' => '/var/vcap/jobs/reverse_log_proxy/config/certs/mutual_tls_ca.crt',
+          'cipher_suites' => 'a:b'
         },
-        "doppler" => {
-          "addrs" => ["dopper-1.service.cf.internal", "doppler-2.service.cf.internal"],
-          "grpc_port" => 4444,
-        },
+        'doppler' => {
+          'addrs' => ['dopper-1.service.cf.internal', 'doppler-2.service.cf.internal'],
+          'grpc_port' => 4444
+        }
       },
-      "metron_endpoint" => {
-        "host" => "10.0.0.1",
-        "grpc_port" => 5555,
+      'metron_endpoint' => {
+        'host' => '10.0.0.1',
+        'grpc_port' => 5555
       },
-      "metric_emitter" => {
-        "interval" => "15m",
+      'metric_emitter' => {
+        'interval' => '15m'
       }
     }
     config = render_template(
       properties,
-      job: "reverse_log_proxy",
-      template: "bin/environment.sh"
+      job: 'reverse_log_proxy',
+      template: 'bin/environment.sh'
     )
 
     expected_config = {
-      "RLP_PORT" => "1111",
-      "MAX_EGRESS_STREAMS" => "1000",
-      "RLP_CERT_FILE" => "/var/vcap/jobs/reverse_log_proxy/config/certs/reverse_log_proxy.crt",
-      "RLP_KEY_FILE" => "/var/vcap/jobs/reverse_log_proxy/config/certs/reverse_log_proxy.key",
-      "RLP_CA_FILE" => "/var/vcap/jobs/reverse_log_proxy/config/certs/mutual_tls_ca.crt",
-      "RLP_CIPHER_SUITES" => "a,b",
-      "RLP_PPROF_PORT" => "2222",
-      "RLP_HEALTH_ADDR" => "localhost:3333",
-      "RLP_METRIC_EMITTER_INTERVAL" => "15m",
-      "ROUTER_ADDRS" => "dopper-1.service.cf.internal:4444,doppler-2.service.cf.internal:4444",
-      "AGENT_ADDR" => "10.0.0.1:5555",
+      'CERT_DIR' => '$JOB_DIR/config/certs',
+      'JOB_DIR' => '/var/vcap/jobs/reverse_log_proxy',
+      'LOG_DIR' => '/var/vcap/sys/log/reverse_log_proxy',
+      'PACKAGE_DIR' => '/var/vcap/packages/reverse_log_proxy',
+      'PACKAGE_EXECUTABLE' => 'rlp',
+      'RUN_DIR' => '/var/vcap/sys/run/reverse_log_proxy',
+      'PIDFILE' => '${RUN_DIR}/reverse_log_proxy.pid',
+      'PROFILE_EXECUTABLE' => '/var/vcap/packages/profiler/profiler.sh',
+      'RLP_PORT' => '1111',
+      'MAX_EGRESS_STREAMS' => '1000',
+      'RLP_CERT_FILE' => '$CERT_DIR/reverse_log_proxy.crt',
+      'RLP_KEY_FILE' => '$CERT_DIR/reverse_log_proxy.key',
+      'RLP_CA_FILE' => '$CERT_DIR/mutual_tls_ca.crt',
+      'RLP_CIPHER_SUITES' => 'a,b',
+      'RLP_PPROF_PORT' => '2222',
+      'RLP_HEALTH_ADDR' => 'localhost:3333',
+      'RLP_METRIC_EMITTER_INTERVAL' => '15m',
+      'ROUTER_ADDRS' => 'dopper-1.service.cf.internal:4444,doppler-2.service.cf.internal:4444',
+      'AGENT_ADDR' => '10.0.0.1:5555'
     }
     expect(config).to eq(expected_config)
   end
 
-  describe "Router configuration" do
-    it "consumes a Doppler link" do
+  describe 'Router configuration' do
+    it 'consumes a Doppler link' do
       links = [Link.new(
-        name: "doppler",
+        name: 'doppler',
         instances: [
-          LinkInstance.new(address: "doppler-1.service.cf.internal"),
-          LinkInstance.new(address: "doppler-2.service.cf.internal"),
+          LinkInstance.new(address: 'doppler-1.service.cf.internal'),
+          LinkInstance.new(address: 'doppler-2.service.cf.internal')
         ],
         properties: {
-          "doppler" => {
-            "grpc_port" => 1111,
+          'doppler' => {
+            'grpc_port' => 1111
           }
         }
       )]
       config = render_template(
         {},
         links: links,
-        job: "reverse_log_proxy",
-        template: "bin/environment.sh"
+        job: 'reverse_log_proxy',
+        template: 'bin/environment.sh'
       )
 
-      expect(config["ROUTER_ADDRS"]).to eq("doppler-1.service.cf.internal:1111,doppler-2.service.cf.internal:1111")
+      expect(config['ROUTER_ADDRS']).to eq('doppler-1.service.cf.internal:1111,doppler-2.service.cf.internal:1111')
     end
   end
 end

--- a/src/profiler.sh
+++ b/src/profiler.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+echo "Finding PProf host:port"
+HOSTS=$(lsof -c "${PACKAGE_EXECUTABLE:0:15}" | grep LISTEN | grep localhost | sed -E 's/rlp.*(localhost:\w+).*/\1/')
+
+let HOST
+for h in $HOSTS; do
+    if curl --fail "$h/debug/pprof/" &> /dev/null 2> /dev/null; then
+        HOST=$h
+        break
+    fi
+done
+
+TEMP_DIR=$(mktemp -d)
+PROFILE_DIR="$TEMP_DIR/profiles"
+mkdir "$PROFILE_DIR"
+
+
+TARBALL_PATH="/tmp/$PACKAGE_EXECUTABLE-$(hostname)-profile-$(date --rfc-3339=date).tgz"
+
+if [ "$HOST" = "" ]; then
+    echo "Unable to find pprof"
+    exit 1
+fi
+
+echo "PProf found at ${HOST}"
+echo "Collecting profiles. This may take a while... "
+curl "$HOST/debug/pprof/" > "$PROFILE_DIR/pprof.html" 2> /dev/null
+curl "$HOST/debug/pprof/goroutine?debug=1" > "$PROFILE_DIR/goroutine.dump" 2> /dev/null
+curl "$HOST/debug/pprof/heap?debug=1" > "$PROFILE_DIR/heap.dump" 2> /dev/null
+curls "$HOST/debug/pprof/profile" > "$PROFILE_DIR/cpu.dump" 2> /dev/null
+curl "$HOST/debug/pprof/trace?seconds=30" > "$PROFILE_DIR/trace.dump" 2> /dev/null
+cp "$PACKAGE_DIR/$PACKAGE_EXECUTABLE" "$PROFILE_DIR/$PACKAGE_EXECUTABLE"
+
+echo "Packaging profiles..."
+pushd $TEMP_DIR > /dev/null
+    tar czf "$TARBALL_PATH" profiles
+popd > /dev/null
+
+rm -rf "$TEMP_DIR"
+
+echo "Profiles located at $TARBALL_PATH"


### PR DESCRIPTION
Added profile collector for the following bosh jobs:

* doppler
* loggregator_trafficcontroller
* reverse_log_proxy
* reverse_log_proxy_gateway
* reverse_log_proxy_gateway_cf_auth_proxy

This allows our users to easily collect PProf profiles for us when filing issues. A user would just have to run the control scripts as root with the `profile` command. The profiler script will collect the profiles and the services binary and place them in a tarball in the `/tmp` directory. They can then bosh scp that file and send it to us.