### PR TITLE
Update indicators.yml.erb

### DIFF
--- a/jobs/doppler/templates/indicators.yml.erb
+++ b/jobs/doppler/templates/indicators.yml.erb
@@ -5,6 +5,7 @@ kind: IndicatorDocument
 metadata:
   labels:
     deployment: <%= spec.deployment %>
+    component: doppler
 
 spec:
   product:


### PR DESCRIPTION
Adds a component metadata tag so that indicators from different jobs don't overwrite each other.