### PR TITLE
Human-readable timestamps

### DIFF
--- a/jobs/doppler/spec
+++ b/jobs/doppler/spec
@@ -57,3 +57,7 @@ properties:
   metron_endpoint.grpc_port:
     description: "The port used to emit grpc messages to the Metron agent"
     default: 3458
+
+  logging.format.timestamp:
+    description: "Format for timestamp in component logs. Valid values are 'deprecated' and 'rfc3339'."
+    default: "deprecated"

--- a/jobs/doppler/templates/bpm.yml.erb
+++ b/jobs/doppler/templates/bpm.yml.erb
@@ -10,7 +10,7 @@ processes:
       ROUTER_CA_FILE: "/var/vcap/jobs/doppler/config/certs/loggregator_ca.crt"
       ROUTER_CIPHER_SUITES: "<%=  p("loggregator.tls.cipher_suites").split(":").join(',') %>"
       GODEBUG: "x509ignoreCN=0"
-
+      USE_RFC339: "<%= p("logging.format.timestamp") == "rfc3339" %>"
       ROUTER_PPROF_PORT: "<%=  p("doppler.pprof_port") %>"
     limits:
       open_files: 65536

--- a/jobs/loggregator_trafficcontroller/spec
+++ b/jobs/loggregator_trafficcontroller/spec
@@ -123,3 +123,6 @@ properties:
   metric_emitter.interval:
     description: "The interval that metrics are emitted to the metron."
     default: "1m"
+  logging.format.timestamp:
+    description: "Format for timestamp in component logs. Valid values are 'deprecated' and 'rfc3339'."
+    default: "deprecated"

--- a/jobs/loggregator_trafficcontroller/templates/bpm.yml.erb
+++ b/jobs/loggregator_trafficcontroller/templates/bpm.yml.erb
@@ -65,5 +65,6 @@ processes:
       LOG_CACHE_SERVER_NAME: "<%= p('logcache.tls.server_name') %>"
       <% end %>
       GODEBUG: "x509ignoreCN=0"
+      USE_RFC339: "<%= p("logging.format.timestamp") == "rfc3339" %>"
     limits:
       open_files: 65536

--- a/jobs/reverse_log_proxy/spec
+++ b/jobs/reverse_log_proxy/spec
@@ -69,3 +69,6 @@ properties:
   metric_emitter.interval:
     description: "The interval that metrics are emitted to the metron."
     default: "1m"
+  logging.format.timestamp:
+    description: "Format for timestamp in component logs. Valid values are 'deprecated' and 'rfc3339'."
+    default: "deprecated"

--- a/jobs/reverse_log_proxy/templates/bpm.yml.erb
+++ b/jobs/reverse_log_proxy/templates/bpm.yml.erb
@@ -24,6 +24,7 @@ processes:
       RLP_PPROF_PORT: "<%= p('reverse_log_proxy.pprof.port') %>"
       RLP_METRIC_EMITTER_INTERVAL: "<%= p('metric_emitter.interval') %>"
       GODEBUG: "x509ignoreCN=0"
+      USE_RFC339: "<%= p("logging.format.timestamp") == "rfc3339" %>"
 
       ROUTER_ADDRS: "<%= ingress_addrs.join(",") %>"
       AGENT_ADDR: "<%= "#{p('metron_endpoint.host')}:#{p('metron_endpoint.grpc_port')}" %>"

--- a/jobs/reverse_log_proxy_gateway/spec
+++ b/jobs/reverse_log_proxy_gateway/spec
@@ -89,3 +89,6 @@ properties:
     description: "TLS private key for metrics server signed by the metrics CA"
   metrics.server_name:
     description: "The server name used in the scrape configuration for the metrics endpoint"
+  logging.format.timestamp:
+    description: "Format for timestamp in component logs. Valid values are 'deprecated' and 'rfc3339'."
+    default: "deprecated"

--- a/jobs/reverse_log_proxy_gateway/templates/bpm.yml.erb
+++ b/jobs/reverse_log_proxy_gateway/templates/bpm.yml.erb
@@ -45,3 +45,4 @@ processes:
       METRICS_CERT_FILE_PATH: "<%= certs_dir %>/metrics.crt"
       METRICS_KEY_FILE_PATH: "<%= certs_dir %>/metrics.key"
       GODEBUG: "x509ignoreCN=0"
+      USE_RFC339: "<%= p("logging.format.timestamp") == "rfc3339" %>"

--- a/src/plumbing/logwriter.go
+++ b/src/plumbing/logwriter.go
@@ -1,0 +1,15 @@
+package plumbing
+
+import (
+	"io"
+	"os"
+	"time"
+)
+
+type LogWriter struct {
+}
+
+func (writer LogWriter) Write(bytes []byte) (int, error) {
+	str := time.Now().UTC().Format("2006-01-02T15:04:05.000000000Z") + " " + string(bytes)
+	return io.WriteString(os.Stderr, str)
+}

--- a/src/rlp-gateway/app/config.go
+++ b/src/rlp-gateway/app/config.go
@@ -42,6 +42,7 @@ type MetricsServer struct {
 
 // Config holds the configuration for the RLP Gateway
 type Config struct {
+	UseRFC339                  bool   `env:"USE_RFC339"`
 	LogsProviderAddr           string `env:"LOGS_PROVIDER_ADDR,             required, report"`
 	LogsProviderCAPath         string `env:"LOGS_PROVIDER_CA_PATH,          required, report"`
 	LogsProviderClientCertPath string `env:"LOGS_PROVIDER_CLIENT_CERT_PATH, required, report"`
@@ -56,7 +57,7 @@ type Config struct {
 
 	StreamTimeout time.Duration `env:"STREAM_TIMEOUT, report"`
 
-	HTTP HTTP
+	HTTP          HTTP
 	MetricsServer MetricsServer
 }
 

--- a/src/rlp/app/config.go
+++ b/src/rlp/app/config.go
@@ -19,6 +19,7 @@ type GRPC struct {
 
 // Config stores all configurations options for RLP.
 type Config struct {
+	UseRFC339             bool          `env:"USE_RFC339"`
 	PProfPort             uint32        `env:"RLP_PPROF_PORT"`
 	MetricEmitterInterval time.Duration `env:"RLP_METRIC_EMITTER_INTERVAL"`
 	MetricSourceID        string        `env:"RLP_METRIC_SOURCE_ID"`

--- a/src/rlp/main.go
+++ b/src/rlp/main.go
@@ -22,13 +22,16 @@ import (
 )
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
-
 	grpclog.SetLogger(log.New(ioutil.Discard, "", 0))
 
 	conf, err := app.LoadConfig()
 	if err != nil {
 		log.Fatalf("Failed to load config: %s", err)
+	}
+	if conf.UseRFC339 {
+		log.SetOutput(new(plumbing.LogWriter))
+	} else {
+		log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 	}
 
 	envstruct.WriteReport(conf)

--- a/src/router/app/config.go
+++ b/src/router/app/config.go
@@ -25,6 +25,7 @@ type GRPC struct {
 type Config struct {
 	GRPC GRPC
 
+	UseRFC339                       bool   `env:"USE_RFC339"`
 	PProfPort                       uint32 `env:"ROUTER_PPROF_PORT"`
 	Agent                           Agent
 	MetricBatchIntervalMilliseconds uint   `env:"ROUTER_METRIC_BATCH_INTERVAL_MILLISECONDS"`

--- a/src/router/main.go
+++ b/src/router/main.go
@@ -7,14 +7,13 @@ import (
 	"time"
 
 	envstruct "code.cloudfoundry.org/go-envstruct"
+	"code.cloudfoundry.org/loggregator/plumbing"
 	"code.cloudfoundry.org/loggregator/profiler"
 	"code.cloudfoundry.org/loggregator/router/app"
 	"google.golang.org/grpc/grpclog"
 )
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
-
 	rand.Seed(time.Now().UnixNano())
 	grpclog.SetLogger(log.New(ioutil.Discard, "", 0))
 
@@ -22,7 +21,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("Unable to parse config: %s", err)
 	}
-
+	if conf.UseRFC339 {
+		log.SetOutput(new(plumbing.LogWriter))
+	} else {
+		log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+	}
 	envstruct.WriteReport(conf)
 
 	r := app.NewRouter(

--- a/src/trafficcontroller/app/config.go
+++ b/src/trafficcontroller/app/config.go
@@ -39,6 +39,7 @@ type CCTLSClientConfig struct {
 
 // Config stores all Configuration options for trafficcontroller.
 type Config struct {
+	UseRFC339             bool          `env:"USE_RFC339"`
 	IP                    string        `env:"TRAFFIC_CONTROLLER_IP, report"`
 	ApiHost               string        `env:"TRAFFIC_CONTROLLER_API_HOST, report"`
 	OutgoingDropsondePort uint32        `env:"TRAFFIC_CONTROLLER_OUTGOING_DROPSONDE_PORT, report"`

--- a/src/trafficcontroller/internal/proxy/websocket_server.go
+++ b/src/trafficcontroller/internal/proxy/websocket_server.go
@@ -34,7 +34,6 @@ func NewWebSocketServer(slowConsumerTimeout time.Duration, m MetricClient) *WebS
 	slowConsumerMetric := m.NewCounter("doppler_proxy.slow_consumer",
 		metricemitter.WithVersion(2, 0),
 	)
-
 	return &WebSocketServer{
 		slowConsumerMetric:  slowConsumerMetric,
 		slowConsumerTimeout: slowConsumerTimeout,

--- a/src/trafficcontroller/main.go
+++ b/src/trafficcontroller/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"code.cloudfoundry.org/tlsconfig"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
+
+	"code.cloudfoundry.org/tlsconfig"
 
 	"code.cloudfoundry.org/loggregator/metricemitter"
 	"code.cloudfoundry.org/loggregator/plumbing"
@@ -17,13 +18,16 @@ import (
 )
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
-
 	grpclog.SetLogger(log.New(ioutil.Discard, "", 0))
 
 	conf, err := app.LoadConfig()
 	if err != nil {
 		log.Panicf("Unable to load config: %s", err)
+	}
+	if conf.UseRFC339 {
+		log.SetOutput(new(plumbing.LogWriter))
+	} else {
+		log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 	}
 
 	credentials, err := plumbing.NewClientCredentials(
@@ -55,6 +59,7 @@ func main() {
 		uaaHTTPClient(conf),
 		ccHTTPClient(conf),
 	)
+
 	tc.Start()
 }
 


### PR DESCRIPTION
* adds property than can allow deprecated or rfc3339
* defaults to deprecated
* overwrites go logger's Writer & Write method to add formatting 

This was manually tested in an SRT toolsmith env.

Signed-off-by: Ben Fuller <bfuller@pivotal.io>