### PR TITLE
[Bionic update] Replace "killall" with "pkill"

### DIFF
--- a/jobs/loggregator_trafficcontroller/templates/drain.erb
+++ b/jobs/loggregator_trafficcontroller/templates/drain.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-killall trafficcontroller
+pkill -f /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller --signal SIGTERM
 rm /var/vcap/sys/run/bpm/loggregator_trafficcontroller/loggregator_trafficcontroller.pid
 echo 5
 exit 0

--- a/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller_ctl.erb
+++ b/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller_ctl.erb
@@ -12,10 +12,10 @@ case $1 in
 
   start)
     set +e
-      killall -15 trafficcontroller
-      killall -9 trafficcontroller
-      killall -2 trafficcontroller
-      killall -3 trafficcontroller
+      pkill -f /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller -15
+      pkill -f /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller -9
+      pkill -f /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller -2
+      pkill -f /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller -3
     set -e
 
     ulimit -n 65536
@@ -32,10 +32,10 @@ case $1 in
 
   stop)
     set +e
-      killall -15 trafficcontroller
-      killall -9 trafficcontroller
-      killall -2 trafficcontroller
-      killall -3 trafficcontroller
+      pkill -f /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller -15
+      pkill -f /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller -9
+      pkill -f /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller -2
+      pkill -f /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller -3
     set -e
 
     rm -f $PIDFILE

--- a/jobs/reverse_log_proxy/templates/drain.erb
+++ b/jobs/reverse_log_proxy/templates/drain.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-killall rlp
+pkill -f /var/vcap/packages/reverse_log_proxy/rlp --signal SIGTERM
 rm /var/vcap/sys/run/bpm/reverse_log_proxy/reverse_log_proxy.pid
 echo 60
 exit 0

--- a/jobs/reverse_log_proxy/templates/pre-start.erb
+++ b/jobs/reverse_log_proxy/templates/pre-start.erb
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Added to alliviate a bug which caused rlp to not exit
-killall -9 rlp || true
+pkill -f /var/vcap/packages/reverse_log_proxy/rlp --signal SIGKILL || true
 rm -f /var/vcap/sys/run/bpm/reverse_log_proxy/reverse_log_proxy.pid

--- a/jobs/reverse_log_proxy/templates/reverse_log_proxy_ctl.erb
+++ b/jobs/reverse_log_proxy/templates/reverse_log_proxy_ctl.erb
@@ -6,10 +6,10 @@ case $1 in
 
   start)
     set +e
-      killall -15 $PACKAGE_EXECUTABLE
-      killall -9 $PACKAGE_EXECUTABLE
-      killall -2 $PACKAGE_EXECUTABLE
-      killall -3 $PACKAGE_EXECUTABLE
+      pkill -f /var/vcap/packages/reverse_log_proxy/rlp -15
+      pkill -f /var/vcap/packages/reverse_log_proxy/rlp -9
+      pkill -f /var/vcap/packages/reverse_log_proxy/rlp -2
+      pkill -f /var/vcap/packages/reverse_log_proxy/rlp -3
     set -e
 
     mkdir -p $RUN_DIR $LOG_DIR
@@ -26,10 +26,10 @@ case $1 in
 
   stop)
     set +e
-      killall -15 $PACKAGE_EXECUTABLE
-      killall -9 $PACKAGE_EXECUTABLE
-      killall -2 $PACKAGE_EXECUTABLE
-      killall -3 $PACKAGE_EXECUTABLE
+      pkill -f /var/vcap/packages/reverse_log_proxy/rlp -15
+      pkill -f /var/vcap/packages/reverse_log_proxy/rlp -9
+      pkill -f /var/vcap/packages/reverse_log_proxy/rlp -2
+      pkill -f /var/vcap/packages/reverse_log_proxy/rlp -3
     set -e
 
     rm -f $PIDFILE

--- a/jobs/reverse_log_proxy_gateway/templates/reverse_log_proxy_gateway_ctl.erb
+++ b/jobs/reverse_log_proxy_gateway/templates/reverse_log_proxy_gateway_ctl.erb
@@ -6,10 +6,10 @@ case $1 in
 
   start)
     set +e
-      killall -15 rlp-gateway
-      killall -9 rlp-gateway
-      killall -2 rlp-gateway
-      killall -3 rlp-gateway
+      pkill -f /var/vcap/packages/reverse_log_proxy_gateway/rlp-gateway -15
+      pkill -f /var/vcap/packages/reverse_log_proxy_gateway/rlp-gateway -9
+      pkill -f /var/vcap/packages/reverse_log_proxy_gateway/rlp-gateway -2
+      pkill -f /var/vcap/packages/reverse_log_proxy_gateway/rlp-gateway -3
     set -e
 
     mkdir -p $RUN_DIR $LOG_DIR
@@ -26,10 +26,10 @@ case $1 in
 
   stop)
     set +e
-      killall -15 rlp-gateway
-      killall -9 rlp-gateway
-      killall -2 rlp-gateway
-      killall -3 rlp-gateway
+      pkill -f /var/vcap/packages/reverse_log_proxy_gateway/rlp-gateway -15
+      pkill -f /var/vcap/packages/reverse_log_proxy_gateway/rlp-gateway -9
+      pkill -f /var/vcap/packages/reverse_log_proxy_gateway/rlp-gateway -2
+      pkill -f /var/vcap/packages/reverse_log_proxy_gateway/rlp-gateway -3
     set -e
 
     rm -f $PIDFILE


### PR DESCRIPTION
* the Bionic stemcell comes with killall in version 23.1 which suffers
  from https://gitlab.com/psmisc/psmisc/-/issues/23
* use pkill instead which works on Xenial as well as Bionic