### PR TITLE
Add overrides for bosh links and override in the proper order

### DIFF
--- a/jobs/loggregator_trafficcontroller/spec
+++ b/jobs/loggregator_trafficcontroller/spec
@@ -76,6 +76,8 @@ properties:
   logcache.tls.server_name:
     description: "The common name of the Log Cache server"
     default: "log-cache"
+  logcache.override_addr:
+    description: "Address for log-cache to override from the default from the bosh link"
 
   loggregator.doppler.addrs:
     description: "The addresses of Dopplers (alternative to doppler link)"

--- a/jobs/loggregator_trafficcontroller/templates/bpm.yml.erb
+++ b/jobs/loggregator_trafficcontroller/templates/bpm.yml.erb
@@ -1,11 +1,10 @@
 <%
   router_addrs = []
 
-  if_link("doppler") do |ds|
-      router_addrs = ds.instances.map{|i| "#{i.address}:#{ds.p('doppler.grpc_port')}"}
-  end.else do
-      paddrs = p("loggregator.doppler.addrs")
+  if_p("loggregator.doppler.addrs") do |paddrs|
       router_addrs = paddrs.map{|addr| "#{addr}:#{p('doppler.grpc_port')}"}
+  end.else_if_link("doppler") do |ds|
+      router_addrs = ds.instances.map{|i| "#{i.address}:#{ds.p('doppler.grpc_port')}"}
   end
 
   # Handle renamed properties
@@ -16,6 +15,13 @@
   end
 
   uaa_host = p("uaa.internal_url")
+
+  log_cache_addr = ""
+  if_p("log-cache.override_addr") do |override_addr|
+    log_cache_addr = override_addr
+  end.else_if_link("log-cache") do |logcache|
+    log_cache_addr = logcache.address
+  end
 %>
 
 processes:
@@ -58,7 +64,7 @@ processes:
       <% end %>
 
       <% if_link("log-cache") do |logcache| %>
-      LOG_CACHE_ADDR: "<%= logcache.address %>:<%= logcache.p('port') %>"
+      LOG_CACHE_ADDR: "<%= log_cache_addr %>:<%= logcache.p('port') %>"
       LOG_CACHE_CA_FILE: "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/logcache_ca.crt"
       LOG_CACHE_CERT_FILE: "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/logcache_trafficcontroller.crt"
       LOG_CACHE_KEY_FILE: "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/logcache_trafficcontroller.key"

--- a/jobs/reverse_log_proxy/templates/bpm.yml.erb
+++ b/jobs/reverse_log_proxy/templates/bpm.yml.erb
@@ -1,12 +1,12 @@
 <%
   ingress_addrs = []
-  if_link("doppler") { |ds|
-      ingress_addrs = ds.instances.map do |instance|
-          "#{instance.address}:#{ds.p('doppler.grpc_port')}"
-      end
-  }.else {
+  if_p("loggregator.doppler.addrs") { |daddrs|
       ingress_addrs = p('loggregator.doppler.addrs').map do |addr|
           "#{addr}:#{p('loggregator.doppler.grpc_port')}"
+      end
+  }.else_if_link("doppler") { |ds|
+      ingress_addrs = ds.instances.map do |instance|
+          "#{instance.address}:#{ds.p('doppler.grpc_port')}"
       end
   }
 %>

--- a/jobs/reverse_log_proxy_gateway/spec
+++ b/jobs/reverse_log_proxy_gateway/spec
@@ -64,6 +64,8 @@ properties:
     description: "The client private key used to authenticate against the internal CC api"
   cc.common_name:
     description: "The CN for the CA cert"
+  cc.address:
+    description: "Override as alternative to using CC link"
 
   uaa.client_id:
     description: "The client id to authenticate to UAA"

--- a/jobs/reverse_log_proxy_gateway/templates/bpm.yml.erb
+++ b/jobs/reverse_log_proxy_gateway/templates/bpm.yml.erb
@@ -1,5 +1,11 @@
 <%
-  cc = link('cloud_controller')
+  cc_address = ""
+  if_p("cc.address") { |addr|
+    cc_address = addr
+  }.else_if_link('cloud_controller') { |cc|
+    cc = link('cloud_controller')
+    cc_address = cc.addr
+  }
 
   certs_dir="/var/vcap/jobs/reverse_log_proxy_gateway/config/certs"
 %>
@@ -26,8 +32,8 @@ processes:
 
       # External ADDR is plaintext because it assumes go-router is doing SSL
       # termination.
-      LOG_ACCESS_ADDR_EXTERNAL: "<%= "http://#{cc.address}:9022" %>"
-      LOG_ACCESS_ADDR: "<%= "https://#{cc.address}:9023" %>"
+      LOG_ACCESS_ADDR_EXTERNAL: "<%= "http://#{cc_address}:9022" %>"
+      LOG_ACCESS_ADDR: "<%= "https://#{cc_address}:9023" %>"
       LOG_ACCESS_CERT_PATH: "<%= certs_dir %>/cc.crt"
       LOG_ACCESS_KEY_PATH: "<%= certs_dir %>/cc.key"
       LOG_ACCESS_CA_PATH: "<%= certs_dir %>/cc_ca.crt"


### PR DESCRIPTION
We need to be able to override use of bosh links.  This fixes two such overrides where it used bosh-links no matter what was defined in the override properties.

It also added a new override property to be able to use a different address than what can be obtained from bosh-links.