### PR TITLE
Fix errors generated by go vet

### DIFF
--- a/src/rlp/internal/egress/server.go
+++ b/src/rlp/internal/egress/server.go
@@ -261,8 +261,6 @@ func (s *Server) BatchedReceiver(r *loggregator_v2.EgressBatchRequest, srv loggr
 			timer.Reset(resetDuration)
 		}
 	}
-
-	return nil
 }
 
 // convergeSelectors takes in any LegacySelector on the request as well as

--- a/src/router/internal/server/v1/ingestor_server_test.go
+++ b/src/router/internal/server/v1/ingestor_server_test.go
@@ -75,7 +75,7 @@ var _ = Describe("IngestorServer", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		someEnvelope, data := buildContainerMetric()
-		err = pusherClient.Send(&plumbing.EnvelopeData{data})
+		err = pusherClient.Send(&plumbing.EnvelopeData{Payload: data})
 		Expect(err).ToNot(HaveOccurred())
 
 		f := func() *events.Envelope {
@@ -95,7 +95,7 @@ var _ = Describe("IngestorServer", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		someEnvelope, data := buildContainerMetric()
-		pusherClient.Send(&plumbing.EnvelopeData{data})
+		pusherClient.Send(&plumbing.EnvelopeData{Payload: data})
 
 		v2e := conversion.ToV2(someEnvelope, true)
 		Eventually(v2Buf.Next).Should(Equal(v2e))
@@ -106,14 +106,14 @@ var _ = Describe("IngestorServer", func() {
 			pusherClient, err := dopplerClient.Pusher(context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 
-			err = pusherClient.Send(&plumbing.EnvelopeData{[]byte("unsupported envelope")})
+			err = pusherClient.Send(&plumbing.EnvelopeData{Payload: []byte("unsupported envelope")})
 			Expect(err).ToNot(HaveOccurred())
 			Consistently(func() bool {
 				_, ok := v1Buf.TryNext()
 				return ok
 			}).Should(BeFalse())
 
-			err = pusherClient.Send(&plumbing.EnvelopeData{nil})
+			err = pusherClient.Send(&plumbing.EnvelopeData{})
 			Expect(err).ToNot(HaveOccurred())
 			Consistently(func() bool {
 				_, ok := v1Buf.TryNext()

--- a/src/router/internal/server/v1/router_benchmark_test.go
+++ b/src/router/internal/server/v1/router_benchmark_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	for i := 0; i < numOfSubs; i++ {
 		r.Register(&plumbing.SubscriptionRequest{Filter: &plumbing.Filter{
 			AppID:   fmt.Sprintf("%d", i%20000),
-			Message: &plumbing.Filter_Log{&plumbing.LogFilter{}},
+			Message: &plumbing.Filter_Log{Log: &plumbing.LogFilter{}},
 		}}, setter)
 	}
 

--- a/src/trafficcontroller/app/traffic_controller.go
+++ b/src/trafficcontroller/app/traffic_controller.go
@@ -160,7 +160,7 @@ func (t *TrafficController) Start() {
 	go t.startServer(dopplerHandler)
 	go profiler.New(t.conf.PProfPort).Start()
 
-	killChan := make(chan os.Signal)
+	killChan := make(chan os.Signal, 1)
 	signal.Notify(killChan, os.Interrupt)
 	<-killChan
 	log.Print("Shutting down")

--- a/src/trafficcontroller/internal/proxy/recent_logs_handler.go
+++ b/src/trafficcontroller/internal/proxy/recent_logs_handler.go
@@ -91,8 +91,7 @@ func (h *RecentLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	appID := mux.Vars(r)["appID"]
 
-	ctx, cancel := context.WithCancel(context.Background())
-	ctx, _ = context.WithDeadline(ctx, time.Now().Add(h.timeout))
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(h.timeout))
 	defer cancel()
 
 	limit, ok := limitFrom(r)


### PR DESCRIPTION
# Description

Fix errors generated by running `go vet ./...` in `src`:
```
# code.cloudfoundry.org/loggregator/rlp/internal/egress
rlp/internal/egress/server.go:265:2: unreachable code
# code.cloudfoundry.org/loggregator/trafficcontroller/internal/proxy
trafficcontroller/internal/proxy/recent_logs_handler.go:95:7: the cancel function returned by context.WithDeadline should be called, not discarded, to avoid a context leak
# code.cloudfoundry.org/loggregator/router/internal/server/v1_test
router/internal/server/v1/ingestor_server_test.go:78:28: code.cloudfoundry.org/loggregator/plumbing.EnvelopeData composite literal uses unkeyed fields
router/internal/server/v1/ingestor_server_test.go:98:22: code.cloudfoundry.org/loggregator/plumbing.EnvelopeData composite literal uses unkeyed fields
router/internal/server/v1/ingestor_server_test.go:109:29: code.cloudfoundry.org/loggregator/plumbing.EnvelopeData composite literal uses unkeyed fields
router/internal/server/v1/ingestor_server_test.go:116:29: code.cloudfoundry.org/loggregator/plumbing.EnvelopeData composite literal uses unkeyed fields
router/internal/server/v1/router_benchmark_test.go:32:14: code.cloudfoundry.org/loggregator/plumbing.Filter_Log composite literal uses unkeyed fields
# code.cloudfoundry.org/loggregator/trafficcontroller/app
trafficcontroller/app/traffic_controller.go:164:2: misuse of unbuffered os.Signal channel as argument to signal.Notify
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

