### PR TITLE
Close log client connections when stopping RLP Gateway

### DIFF
--- a/src/rlp-gateway/internal/ingress/log_client.go
+++ b/src/rlp-gateway/internal/ingress/log_client.go
@@ -13,7 +13,8 @@ import (
 
 // LogClient handles dialing and opening streams to the logs provider.
 type LogClient struct {
-	c loggregator_v2.EgressClient
+	c          loggregator_v2.EgressClient
+	connection *grpc.ClientConn
 }
 
 // NewClient dials the logs provider and returns a new log client.
@@ -28,7 +29,8 @@ func NewLogClient(creds credentials.TransportCredentials, logsProviderAddr strin
 	}
 	client := loggregator_v2.NewEgressClient(conn)
 	return &LogClient{
-		c: client,
+		c:          client,
+		connection: conn,
 	}
 }
 
@@ -40,4 +42,8 @@ func (c *LogClient) Stream(ctx context.Context, req *loggregator_v2.EgressBatchR
 	}
 
 	return receiver.Recv
+}
+
+func (c *LogClient) Close() error {
+	return c.connection.Close()
 }


### PR DESCRIPTION
- Unit tests had been failing on some workstations due to the large
  number of open file handles
- The RLP Gateway creates 20 connections in the log client
- Close the gRPC connections when stopping the RLP Gateway

Fixes:

  failed to start listener: listen tcp :0: socket: too many open files

Signed-off-by: Ben Fuller <benjaminf@vmware.com>
(cherry picked from commit 1820c67f5a493961b9d2224e7706468cbb02fb2a)

# Description

Please include a summary of the change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

