### PR TITLE
Fix: race condition in the v1 ingestor server tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: "src/go.mod"
-      - run: go run github.com/onsi/ginkgo/ginkgo -r -race -randomizeAllSpecs -randomizeSuites
+      - run: go run github.com/onsi/ginkgo/ginkgo -r -race -randomizeAllSpecs -randomizeSuites -keepGoing
         working-directory: src
 
   vet:


### PR DESCRIPTION
# Description

There was a recurring race condition because of a goroutine that was running the `Pusher` method on manager, and the BeforeEach which would assign a new v1 `IngestorServer` to manager.

This change stops the goroutine after it's not needed, and waits for it to close before completing the `It` test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
