### PR TITLE
Don't wait for log-cache to be available

### DIFF
--- a/src/integration_tests/trafficcontroller/end_to_end_test.go
+++ b/src/integration_tests/trafficcontroller/end_to_end_test.go
@@ -3,6 +3,7 @@ package trafficcontroller_test
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -82,223 +83,298 @@ var _ = Describe("TrafficController for v1 messages", func() {
 	})
 
 	Context("with a configured log cache", func() {
-		BeforeEach(func() {
-			fakeDoppler = NewFakeDoppler()
-			err := fakeDoppler.Start()
-			Expect(err).ToNot(HaveOccurred())
+		Context("when log cache is available", func() {
+			BeforeEach(func() {
+				fakeDoppler = NewFakeDoppler()
+				err := fakeDoppler.Start()
+				Expect(err).ToNot(HaveOccurred())
 
-			logCache = newStubGrpcLogCache()
-			cfg := testservers.BuildTrafficControllerConf(fakeDoppler.Addr(), 37474, logCache.addr())
+				logCache = newStubGrpcLogCache()
+				cfg := testservers.BuildTrafficControllerConf(fakeDoppler.Addr(), 37474, logCache.addr())
 
-			var tcPorts testservers.TrafficControllerPorts
-			tcCleanupFunc, tcPorts = testservers.StartTrafficController(cfg)
+				var tcPorts testservers.TrafficControllerPorts
+				tcCleanupFunc, tcPorts = testservers.StartTrafficController(cfg)
 
-			wsPort = tcPorts.WS
+				wsPort = tcPorts.WS
 
-			tcHTTPEndpoint := fmt.Sprintf("https://%s:%d", localIPAddress, tcPorts.WS)
-			tcWSEndpoint = fmt.Sprintf("wss://%s:%d", localIPAddress, tcPorts.WS)
+				tcHTTPEndpoint := fmt.Sprintf("https://%s:%d", localIPAddress, tcPorts.WS)
+				tcWSEndpoint = fmt.Sprintf("wss://%s:%d", localIPAddress, tcPorts.WS)
 
-			// wait for TC
-			Eventually(func() error {
-				resp, err := httpClient.Get(tcHTTPEndpoint)
-				if err == nil {
-					resp.Body.Close()
-				}
-				return err
-			}, 10).Should(Succeed())
-		})
+				// wait for TC
+				Eventually(func() error {
+					resp, err := httpClient.Get(tcHTTPEndpoint)
+					if err == nil {
+						resp.Body.Close()
+					}
+					return err
+				}, 10).Should(Succeed())
+			})
 
-		AfterEach(func(done Done) {
-			defer close(done)
-			fakeDoppler.Stop()
-			logCache.stop()
-		}, 30)
+			AfterEach(func(done Done) {
+				defer close(done)
+				fakeDoppler.Stop()
+				logCache.stop()
+			}, 30)
 
-		Describe("Loggregator Router Paths", func() {
-			Context("Streaming", func() {
-				var (
-					client   *consumer.Consumer
-					messages <-chan *events.Envelope
-					errors   <-chan error
-				)
+			Describe("Loggregator Router Paths", func() {
+				Context("Streaming", func() {
+					var (
+						client   *consumer.Consumer
+						messages <-chan *events.Envelope
+						errors   <-chan error
+					)
 
-				BeforeEach(func() {
-					client = consumer.New(tcWSEndpoint, &tls.Config{
-						InsecureSkipVerify: true, //nolint:gosec
-					}, nil)
-					messages, errors = client.StreamWithoutReconnect(APP_ID, AUTH_TOKEN)
+					BeforeEach(func() {
+						client = consumer.New(tcWSEndpoint, &tls.Config{
+							InsecureSkipVerify: true, //nolint:gosec
+						}, nil)
+						messages, errors = client.StreamWithoutReconnect(APP_ID, AUTH_TOKEN)
+					})
+
+					It("passes messages through", func() {
+						var grpcRequest *plumbing.SubscriptionRequest
+						Eventually(fakeDoppler.SubscriptionRequests, 10).Should(Receive(&grpcRequest))
+						Expect(grpcRequest.Filter).ToNot(BeNil())
+						Expect(grpcRequest.Filter.AppID).To(Equal(APP_ID))
+
+						currentTime := time.Now().UnixNano()
+						dropsondeMessage := makeDropsondeMessage("Hello through NOAA", APP_ID, currentTime)
+						fakeDoppler.SendLogMessage(dropsondeMessage)
+
+						var receivedEnvelope *events.Envelope
+						Eventually(messages).Should(Receive(&receivedEnvelope))
+						Consistently(errors).ShouldNot(Receive())
+
+						receivedMessage := receivedEnvelope.GetLogMessage()
+						Expect(receivedMessage.GetMessage()).To(BeEquivalentTo("Hello through NOAA"))
+						Expect(receivedMessage.GetAppId()).To(Equal(APP_ID))
+						Expect(receivedMessage.GetTimestamp()).To(Equal(currentTime))
+
+						client.Close()
+					})
+
+					It("closes the upstream websocket connection when done", func() {
+						var server plumbing.Doppler_BatchSubscribeServer
+						Eventually(fakeDoppler.SubscribeServers, 10).Should(Receive(&server))
+
+						client.Close()
+
+						Eventually(server.Context().Done()).Should(BeClosed())
+					})
 				})
 
-				It("passes messages through", func() {
-					var grpcRequest *plumbing.SubscriptionRequest
-					Eventually(fakeDoppler.SubscriptionRequests, 10).Should(Receive(&grpcRequest))
-					Expect(grpcRequest.Filter).ToNot(BeNil())
-					Expect(grpcRequest.Filter.AppID).To(Equal(APP_ID))
+				Context("Firehose", func() {
+					var (
+						messages <-chan *events.Envelope
+						errors   <-chan error
+					)
 
-					currentTime := time.Now().UnixNano()
-					dropsondeMessage := makeDropsondeMessage("Hello through NOAA", APP_ID, currentTime)
-					fakeDoppler.SendLogMessage(dropsondeMessage)
+					It("passes messages through for every app for uaa admins", func() {
+						client := consumer.New(tcWSEndpoint, &tls.Config{
+							InsecureSkipVerify: true, //nolint:gosec
+						}, nil)
+						defer client.Close()
+						messages, errors = client.FirehoseWithoutReconnect(SUBSCRIPTION_ID, AUTH_TOKEN)
 
-					var receivedEnvelope *events.Envelope
-					Eventually(messages).Should(Receive(&receivedEnvelope))
-					Consistently(errors).ShouldNot(Receive())
+						var grpcRequest *plumbing.SubscriptionRequest
+						Eventually(fakeDoppler.SubscriptionRequests, 10).Should(Receive(&grpcRequest))
+						Expect(grpcRequest.ShardID).To(Equal(SUBSCRIPTION_ID))
 
-					receivedMessage := receivedEnvelope.GetLogMessage()
-					Expect(receivedMessage.GetMessage()).To(BeEquivalentTo("Hello through NOAA"))
-					Expect(receivedMessage.GetAppId()).To(Equal(APP_ID))
-					Expect(receivedMessage.GetTimestamp()).To(Equal(currentTime))
+						currentTime := time.Now().UnixNano()
+						dropsondeMessage := makeDropsondeMessage("Hello through NOAA", APP_ID, currentTime)
+						fakeDoppler.SendLogMessage(dropsondeMessage)
 
-					client.Close()
+						var receivedEnvelope *events.Envelope
+						Eventually(messages).Should(Receive(&receivedEnvelope))
+						Consistently(errors).ShouldNot(Receive())
+
+						Expect(receivedEnvelope.GetEventType()).To(Equal(events.Envelope_LogMessage))
+						receivedMessage := receivedEnvelope.GetLogMessage()
+						Expect(receivedMessage.GetMessage()).To(BeEquivalentTo("Hello through NOAA"))
+						Expect(receivedMessage.GetAppId()).To(Equal(APP_ID))
+						Expect(receivedMessage.GetTimestamp()).To(Equal(currentTime))
+					})
 				})
 
-				It("closes the upstream websocket connection when done", func() {
-					var server plumbing.Doppler_BatchSubscribeServer
-					Eventually(fakeDoppler.SubscribeServers, 10).Should(Receive(&server))
+			})
 
-					client.Close()
+			Describe("LogCache API Paths", func() {
+				Context("Recent", func() {
+					It("returns a multi-part HTTP response with all recent messages", func() {
+						client := consumer.New(tcWSEndpoint, &tls.Config{
+							InsecureSkipVerify: true, //nolint:gosec
+						}, nil)
 
-					Eventually(server.Context().Done()).Should(BeClosed())
+						Eventually(func() int {
+							messages, err := client.RecentLogs("efe5c422-e8a7-42c2-a52b-98bffd8d6a07", "bearer iAmAnAdmin")
+							Expect(err).NotTo(HaveOccurred())
+
+							if len(logCache.requests()) > 0 {
+								Expect(logCache.requests()[0].SourceId).To(Equal("efe5c422-e8a7-42c2-a52b-98bffd8d6a07"))
+							}
+
+							return len(messages)
+						}, 5).Should(Equal(2))
+					})
 				})
 			})
 
-			Context("Firehose", func() {
-				var (
-					messages <-chan *events.Envelope
-					errors   <-chan error
-				)
+			Context("SetCookie", func() {
+				It("sets the desired cookie on the response", func() {
+					response, err := httpClient.PostForm(
+						fmt.Sprintf("https://%s:%d/set-cookie",
+							localIPAddress,
+							wsPort,
+						),
+						url.Values{
+							"CookieName":  {"authorization"},
+							"CookieValue": {url.QueryEscape("bearer iAmAnAdmin")},
+						},
+					)
+					Expect(err).NotTo(HaveOccurred())
 
-				It("passes messages through for every app for uaa admins", func() {
-					client := consumer.New(tcWSEndpoint, &tls.Config{
-						InsecureSkipVerify: true, //nolint:gosec
-					}, nil)
+					Expect(response.Cookies()).NotTo(BeNil())
+					Expect(response.Cookies()).To(HaveLen(1))
+					cookie := response.Cookies()[0]
+					Expect(cookie.Domain).To(Equal("doppler.vcap.me"))
+					Expect(cookie.Name).To(Equal("authorization"))
+					Expect(cookie.Value).To(Equal("bearer+iAmAnAdmin"))
+					Expect(cookie.Secure).To(BeTrue())
+				})
+			})
+
+			Describe("TLS security", func() {
+				DescribeTable("allows only supported TLS versions", func(clientTLSVersion int, serverShouldAllow bool) {
+					tlsConfig := buildTLSConfig(uint16(clientTLSVersion), tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+					client := consumer.New(tcWSEndpoint, tlsConfig, nil)
+					_, errors := client.StreamWithoutReconnect(APP_ID, AUTH_TOKEN)
+
 					defer client.Close()
-					messages, errors = client.FirehoseWithoutReconnect(SUBSCRIPTION_ID, AUTH_TOKEN)
 
-					var grpcRequest *plumbing.SubscriptionRequest
-					Eventually(fakeDoppler.SubscriptionRequests, 10).Should(Receive(&grpcRequest))
-					Expect(grpcRequest.ShardID).To(Equal(SUBSCRIPTION_ID))
-
-					currentTime := time.Now().UnixNano()
-					dropsondeMessage := makeDropsondeMessage("Hello through NOAA", APP_ID, currentTime)
-					fakeDoppler.SendLogMessage(dropsondeMessage)
-
-					var receivedEnvelope *events.Envelope
-					Eventually(messages).Should(Receive(&receivedEnvelope))
-					Consistently(errors).ShouldNot(Receive())
-
-					Expect(receivedEnvelope.GetEventType()).To(Equal(events.Envelope_LogMessage))
-					receivedMessage := receivedEnvelope.GetLogMessage()
-					Expect(receivedMessage.GetMessage()).To(BeEquivalentTo("Hello through NOAA"))
-					Expect(receivedMessage.GetAppId()).To(Equal(APP_ID))
-					Expect(receivedMessage.GetTimestamp()).To(Equal(currentTime))
-				})
-			})
-
-		})
-
-		Describe("LogCache API Paths", func() {
-			Context("Recent", func() {
-				It("returns a multi-part HTTP response with all recent messages", func() {
-					client := consumer.New(tcWSEndpoint, &tls.Config{
-						InsecureSkipVerify: true, //nolint:gosec
-					}, nil)
-
-					Eventually(func() int {
-						messages, err := client.RecentLogs("efe5c422-e8a7-42c2-a52b-98bffd8d6a07", "bearer iAmAnAdmin")
-						Expect(err).NotTo(HaveOccurred())
-
-						if len(logCache.requests()) > 0 {
-							Expect(logCache.requests()[0].SourceId).To(Equal("efe5c422-e8a7-42c2-a52b-98bffd8d6a07"))
-						}
-
-						return len(messages)
-					}, 5).Should(Equal(2))
-				})
-			})
-		})
-
-		Context("SetCookie", func() {
-			It("sets the desired cookie on the response", func() {
-				response, err := httpClient.PostForm(
-					fmt.Sprintf("https://%s:%d/set-cookie",
-						localIPAddress,
-						wsPort,
-					),
-					url.Values{
-						"CookieName":  {"authorization"},
-						"CookieValue": {url.QueryEscape("bearer iAmAnAdmin")},
-					},
+					if serverShouldAllow {
+						Consistently(errors).ShouldNot(Receive())
+					} else {
+						Eventually(errors).Should(Receive())
+					}
+				},
+					Entry("unsupported SSL 3.0", tls.VersionSSL30, false), //nolint:staticcheck
+					Entry("unsupported TLS 1.0", tls.VersionTLS10, false),
+					Entry("unsupported TLS 1.1", tls.VersionTLS11, false),
+					Entry("supported TLS 1.2", tls.VersionTLS12, true),
 				)
-				Expect(err).NotTo(HaveOccurred())
 
-				Expect(response.Cookies()).NotTo(BeNil())
-				Expect(response.Cookies()).To(HaveLen(1))
-				cookie := response.Cookies()[0]
-				Expect(cookie.Domain).To(Equal("doppler.vcap.me"))
-				Expect(cookie.Name).To(Equal("authorization"))
-				Expect(cookie.Value).To(Equal("bearer+iAmAnAdmin"))
-				Expect(cookie.Secure).To(BeTrue())
+				DescribeTable("allows only supported TLS versions", func(cipherSuite uint16, serverShouldAllow bool) {
+					tlsConfig := buildTLSConfig(tls.VersionTLS12, cipherSuite)
+					client := consumer.New(tcWSEndpoint, tlsConfig, nil)
+					_, errors := client.StreamWithoutReconnect(APP_ID, AUTH_TOKEN)
+
+					defer client.Close()
+
+					if serverShouldAllow {
+						Consistently(errors).ShouldNot(Receive())
+					} else {
+						Eventually(errors).Should(Receive())
+					}
+				},
+					Entry("unsupported cipher RSA_WITH_3DES_EDE_CBC_SHA", tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, false),
+					Entry("unsupported cipher ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, false),
+					Entry("unsupported cipher RSA_WITH_RC4_128_SHA", tls.TLS_RSA_WITH_RC4_128_SHA, false),
+					Entry("unsupported cipher RSA_WITH_AES_128_CBC_SHA256", tls.TLS_RSA_WITH_AES_128_CBC_SHA256, false),
+					Entry("unsupported cipher ECDHE_ECDSA_WITH_CHACHA20_POLY1305", tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, false),
+					Entry("unsupported cipher ECDHE_ECDSA_WITH_RC4_128_SHA", tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA, false),
+					Entry("unsupported cipher ECDHE_ECDSA_WITH_AES_128_CBC_SHA", tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, false),
+					Entry("unsupported cipher ECDHE_ECDSA_WITH_AES_256_CBC_SHA", tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, false),
+					Entry("unsupported cipher ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, false),
+					Entry("unsupported cipher ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, false),
+					Entry("unsupported cipher ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, false),
+					Entry("unsupported cipher ECDHE_RSA_WITH_RC4_128_SHA", tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA, false),
+					Entry("unsupported cipher ECDHE_RSA_WITH_AES_128_CBC_SHA256", tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, false),
+					Entry("unsupported cipher ECDHE_RSA_WITH_AES_128_CBC_SHA", tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, false),
+					Entry("unsupported cipher ECDHE_RSA_WITH_AES_256_CBC_SHA", tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, false),
+					Entry("unsupported cipher ECDHE_RSA_WITH_CHACHA20_POLY1305", tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, false),
+					Entry("unsupported cipher RSA_WITH_AES_128_CBC_SHA", tls.TLS_RSA_WITH_AES_128_CBC_SHA, false),
+					Entry("unsupported cipher RSA_WITH_AES_128_GCM_SHA256", tls.TLS_RSA_WITH_AES_128_GCM_SHA256, false),
+					Entry("unsupported cipher RSA_WITH_AES_256_CBC_SHA", tls.TLS_RSA_WITH_AES_256_CBC_SHA, false),
+					Entry("unsupported cipher RSA_WITH_AES_256_GCM_SHA384", tls.TLS_RSA_WITH_AES_256_GCM_SHA384, false),
+
+					Entry("supported cipher ECDHE_RSA_WITH_AES_128_GCM_SHA256", tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, true),
+					Entry("supported cipher ECDHE_RSA_WITH_AES_256_GCM_SHA384", tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, true),
+				)
 			})
+
 		})
-
-		Describe("TLS security", func() {
-			DescribeTable("allows only supported TLS versions", func(clientTLSVersion int, serverShouldAllow bool) {
-				tlsConfig := buildTLSConfig(uint16(clientTLSVersion), tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
-				client := consumer.New(tcWSEndpoint, tlsConfig, nil)
-				_, errors := client.StreamWithoutReconnect(APP_ID, AUTH_TOKEN)
-
-				defer client.Close()
-
-				if serverShouldAllow {
-					Consistently(errors).ShouldNot(Receive())
-				} else {
-					Eventually(errors).Should(Receive())
-				}
-			},
-				Entry("unsupported SSL 3.0", tls.VersionSSL30, false), //nolint:staticcheck
-				Entry("unsupported TLS 1.0", tls.VersionTLS10, false),
-				Entry("unsupported TLS 1.1", tls.VersionTLS11, false),
-				Entry("supported TLS 1.2", tls.VersionTLS12, true),
+		Context("when log cache is unavailable", func() {
+			var (
+				client   *consumer.Consumer
+				messages <-chan *events.Envelope
+				errors   <-chan error
 			)
 
-			DescribeTable("allows only supported TLS versions", func(cipherSuite uint16, serverShouldAllow bool) {
-				tlsConfig := buildTLSConfig(tls.VersionTLS12, cipherSuite)
-				client := consumer.New(tcWSEndpoint, tlsConfig, nil)
-				_, errors := client.StreamWithoutReconnect(APP_ID, AUTH_TOKEN)
+			BeforeEach(func() {
+				fakeDoppler = NewFakeDoppler()
+				err := fakeDoppler.Start()
+				Expect(err).ToNot(HaveOccurred())
 
-				defer client.Close()
+				lis, err := net.Listen("tcp", "127.0.0.1:0")
+				Expect(err).ToNot(HaveOccurred())
 
-				if serverShouldAllow {
-					Consistently(errors).ShouldNot(Receive())
-				} else {
-					Eventually(errors).Should(Receive())
-				}
-			},
-				Entry("unsupported cipher RSA_WITH_3DES_EDE_CBC_SHA", tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA, false),
-				Entry("unsupported cipher ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, false),
-				Entry("unsupported cipher RSA_WITH_RC4_128_SHA", tls.TLS_RSA_WITH_RC4_128_SHA, false),
-				Entry("unsupported cipher RSA_WITH_AES_128_CBC_SHA256", tls.TLS_RSA_WITH_AES_128_CBC_SHA256, false),
-				Entry("unsupported cipher ECDHE_ECDSA_WITH_CHACHA20_POLY1305", tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, false),
-				Entry("unsupported cipher ECDHE_ECDSA_WITH_RC4_128_SHA", tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA, false),
-				Entry("unsupported cipher ECDHE_ECDSA_WITH_AES_128_CBC_SHA", tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, false),
-				Entry("unsupported cipher ECDHE_ECDSA_WITH_AES_256_CBC_SHA", tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, false),
-				Entry("unsupported cipher ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, false),
-				Entry("unsupported cipher ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, false),
-				Entry("unsupported cipher ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, false),
-				Entry("unsupported cipher ECDHE_RSA_WITH_RC4_128_SHA", tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA, false),
-				Entry("unsupported cipher ECDHE_RSA_WITH_AES_128_CBC_SHA256", tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, false),
-				Entry("unsupported cipher ECDHE_RSA_WITH_AES_128_CBC_SHA", tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, false),
-				Entry("unsupported cipher ECDHE_RSA_WITH_AES_256_CBC_SHA", tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, false),
-				Entry("unsupported cipher ECDHE_RSA_WITH_CHACHA20_POLY1305", tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, false),
-				Entry("unsupported cipher RSA_WITH_AES_128_CBC_SHA", tls.TLS_RSA_WITH_AES_128_CBC_SHA, false),
-				Entry("unsupported cipher RSA_WITH_AES_128_GCM_SHA256", tls.TLS_RSA_WITH_AES_128_GCM_SHA256, false),
-				Entry("unsupported cipher RSA_WITH_AES_256_CBC_SHA", tls.TLS_RSA_WITH_AES_256_CBC_SHA, false),
-				Entry("unsupported cipher RSA_WITH_AES_256_GCM_SHA384", tls.TLS_RSA_WITH_AES_256_GCM_SHA384, false),
+				err = lis.Close()
+				Expect(err).ToNot(HaveOccurred())
 
-				Entry("supported cipher ECDHE_RSA_WITH_AES_128_GCM_SHA256", tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, true),
-				Entry("supported cipher ECDHE_RSA_WITH_AES_256_GCM_SHA384", tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, true),
-			)
+				cfg := testservers.BuildTrafficControllerConf(fakeDoppler.Addr(), 37474, lis.Addr().String())
+
+				var tcPorts testservers.TrafficControllerPorts
+				tcCleanupFunc, tcPorts = testservers.StartTrafficController(cfg)
+
+				wsPort = tcPorts.WS
+
+				tcHTTPEndpoint := fmt.Sprintf("https://%s:%d", localIPAddress, tcPorts.WS)
+				tcWSEndpoint = fmt.Sprintf("wss://%s:%d", localIPAddress, tcPorts.WS)
+
+				// wait for TC
+				Eventually(func() error {
+					resp, err := httpClient.Get(tcHTTPEndpoint)
+					if err == nil {
+						resp.Body.Close()
+					}
+					return err
+				}, 10).Should(Succeed())
+
+				client = consumer.New(tcWSEndpoint, &tls.Config{
+					InsecureSkipVerify: true, //nolint:gosec
+				}, nil)
+				messages, errors = client.StreamWithoutReconnect(APP_ID, AUTH_TOKEN)
+			})
+
+			AfterEach(func(done Done) {
+				defer close(done)
+				fakeDoppler.Stop()
+			}, 30)
+
+			It("still passes messages through", func() {
+				var grpcRequest *plumbing.SubscriptionRequest
+				Eventually(fakeDoppler.SubscriptionRequests, 10).Should(Receive(&grpcRequest))
+				Expect(grpcRequest.Filter).ToNot(BeNil())
+				Expect(grpcRequest.Filter.AppID).To(Equal(APP_ID))
+
+				currentTime := time.Now().UnixNano()
+				dropsondeMessage := makeDropsondeMessage("Hello through NOAA", APP_ID, currentTime)
+				fakeDoppler.SendLogMessage(dropsondeMessage)
+
+				var receivedEnvelope *events.Envelope
+				Eventually(messages).Should(Receive(&receivedEnvelope))
+				Consistently(errors).ShouldNot(Receive())
+
+				receivedMessage := receivedEnvelope.GetLogMessage()
+				Expect(receivedMessage.GetMessage()).To(BeEquivalentTo("Hello through NOAA"))
+				Expect(receivedMessage.GetAppId()).To(Equal(APP_ID))
+				Expect(receivedMessage.GetTimestamp()).To(Equal(currentTime))
+
+				client.Close()
+			})
+
 		})
+
 	})
 })
 

--- a/src/trafficcontroller/app/traffic_controller.go
+++ b/src/trafficcontroller/app/traffic_controller.go
@@ -117,7 +117,6 @@ func (t *TrafficController) Start() {
 			logcache.WithViaGRPC(
 				grpc.WithTransportCredentials(logCacheCreds),
 				grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
-				grpc.WithBlock(),
 			),
 		)
 		recentLogsEnabled = true


### PR DESCRIPTION
- traffic controller was not starting until log cache was available. This causes unnecessary downtime for nozzles, which is the primary purpose of traffic controller these days. During deploys this can cause long outages.
- we went through the history to attempt to find why it was blocking in the first place and were not able to establish why it was added.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes