### PR TITLE
CI: update dependabot config for v106.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,20 +4,29 @@ updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: main
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "v106.x"
+    schedule:
+      interval: "daily"
+    labels:
+    - "v106.x"
+    - "github_actions"
+    - "dependencies"
 
   # Maintain dependencies for Go Modules
   - package-ecosystem: "gomod"
     directory: "/src"
-    target-branch: main
     schedule:
       interval: "daily"
-
-  # Maintain dependencies for Go Modules
   - package-ecosystem: "gomod"
     directory: "/src"
-    target-branch: v106.x
+    target-branch: "v106.x"
     schedule:
       interval: "daily"
+    labels:
+    - "v106.x"
+    - "go"
+    - "dependencies"


### PR DESCRIPTION
# Description

* Also update gh actions dependencies.
* Include a `v106.x` label to make it clear which PRs are for which branch.

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
