### PR TITLE
CI: run go workflow against PRs in v106.x branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,10 +3,10 @@ name: Go
 on:
   push:
     branches:
-    - main
+    - v106.x
   pull_request:
     branches:
-    - main
+    - v106.x
 
 jobs:
   test:


### PR DESCRIPTION
# Description

Without this, GH actions will not be run against PRs to the v106.x branch.

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
