### PR TITLE
Remove documentation for recentlogs endpoint

### DIFF
--- a/docs/trafficcontroller.md
+++ b/docs/trafficcontroller.md
@@ -63,7 +63,6 @@ Traffic Controller exposes a few endpoints from which clients like
 | Endpoint                      | Description                                                    |
 |-------------------------------|----------------------------------------------------------------|
 |`/apps/APP_ID/stream`          | Opens a websocket connection that streams metrics and logs for the specified app ID. The types of available metrics are specified by [this function](https://github.com/cloudfoundry/dropsonde/blob/master/envelope_extensions/envelope_extensions.go#L12). Any metric or log that has an app ID will be sent.|
-|`/apps/APP_ID/recentlogs`      | Returns an HTTP response with the most recent logs for the specified application. The number of logs returned can be configured via the Doppler property `doppler.maxRetainedLogMessages`. Note this endpoint supports a `limit` query param, which will return only the number of logs as specified by the query up to the maximum number of retained application logs. |
 |`/apps/APP_ID/containermetrics`| Returns an HTTP response with the latest container metrics for the specified application. |
 |`/firehose/SUBSCRIPTION_ID`    | Opens a websocket connection that streams the firehose. Connections with the same subscription id will get an equal portion of the firehose data.|
 |`/set-cookie`                  | Sets a cookie with name and value obtained from FormValues `CookieName` and `CookieValue`. It also sets the headers `Access-Control-Allow-Credentials` and `Access-Control-Allow-Origin`.|


### PR DESCRIPTION
After the endpoint was removed with https://github.com/cloudfoundry/loggregator-release/pull/486 we should also remove its documentation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
