### PR TITLE
Remove unused metron_endpoint.dropsonde_port property

### DIFF
--- a/jobs/loggregator_trafficcontroller/spec
+++ b/jobs/loggregator_trafficcontroller/spec
@@ -76,9 +76,6 @@ properties:
   metron_endpoint.host:
     description: "The host used to emit messages to the Metron agent"
     default: "127.0.0.1"
-  metron_endpoint.dropsonde_port:
-    description: "The port used to emit dropsonde messages to the Metron agent"
-    default: 3457
   metron_endpoint.grpc_port:
     description: "The port used to emit grpc messages to the Metron agent"
     default: 3458

--- a/jobs/loggregator_trafficcontroller/templates/bpm.yml.erb
+++ b/jobs/loggregator_trafficcontroller/templates/bpm.yml.erb
@@ -21,7 +21,6 @@ processes:
   - name: loggregator_trafficcontroller
     executable: /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller
     env:
-      AGENT_UDP_ADDRESS: "<%= p('metron_endpoint.host').to_s + ":" + p('metron_endpoint.dropsonde_port').to_s %>"
       AGENT_GRPC_ADDRESS: "<%= p('metron_endpoint.host').to_s + ":" + p('metron_endpoint.grpc_port').to_s %>"
 
       ROUTER_ADDRS: "<%= router_addrs.join(",") %>"

--- a/src/testservers/traffic_controller.go
+++ b/src/testservers/traffic_controller.go
@@ -36,7 +36,7 @@ func BuildTrafficControllerConf(routerAddr string, agentPort int) tcConf.Config 
 			ServerName: "cloud-controller",
 		},
 		Agent: tcConf.Agent{
-			UDPAddress: fmt.Sprintf("localhost:%d", agentPort),
+			GRPCAddress: fmt.Sprintf("localhost:%d", agentPort),
 		},
 		GRPC: tcConf.GRPC{
 			CertFile: LoggregatorTestCerts.Cert("trafficcontroller"),

--- a/src/trafficcontroller/app/config.go
+++ b/src/trafficcontroller/app/config.go
@@ -10,7 +10,6 @@ import (
 
 // Agent stores configuration for communication to a logging/metric agent.
 type Agent struct {
-	UDPAddress  string `env:"AGENT_UDP_ADDRESS"`
 	GRPCAddress string `env:"AGENT_GRPC_ADDRESS"`
 }
 


### PR DESCRIPTION
## Description

- Remove unused BOSH property `metron_endpoint.dropsonde_port` and associated config field from traffic controller
- Pass GRPCAddress rather than UDPAddress when creating a test server. gRPC-Go v1.52.0+ will error if the provided endpoint is empty: https://github.com/grpc/grpc-go/pull/5732

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
