### PR TITLE
fix(grpcconnector): Correctly disconnect dopplers

### DIFF
--- a/src/plumbing/grpc_connector.go
+++ b/src/plumbing/grpc_connector.go
@@ -150,6 +150,8 @@ func (c *GRPCConnector) handleFinderEvent(uris []string) {
 	}
 
 	for _, deadClient := range deadClients {
+		deadClient := deadClient
+
 		log.Printf("Disabling reconnects for doppler %s", deadClient.uri)
 		deadClient.disconnect = true
 

--- a/src/rlp/internal/ingress/grpc_connector.go
+++ b/src/rlp/internal/ingress/grpc_connector.go
@@ -145,6 +145,8 @@ func (c *GRPCConnector) handleFinderEvent(uris []string) {
 	}
 
 	for _, deadClient := range deadClients {
+		deadClient := deadClient
+
 		log.Printf("Disabling reconnects for doppler %s", deadClient.uri)
 		deadClient.disconnect = true
 


### PR DESCRIPTION
# Description

Previously, implicit memory aliasing meant that we were only disconnecting one doppler connection at a time. I'm unsure what the exact impact of this bug was.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
