### PR TITLE
chore: Pin noaa to v2.2.0

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -57,3 +57,5 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/cloudfoundry/noaa/v2 => github.com/cloudfoundry/noaa/v2 v2.2.0

--- a/src/vendor/modules.txt
+++ b/src/vendor/modules.txt
@@ -41,7 +41,7 @@ github.com/blang/semver
 # github.com/cespare/xxhash/v2 v2.2.0
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/cloudfoundry/noaa/v2 v2.2.0
+# github.com/cloudfoundry/noaa/v2 v2.2.0 => github.com/cloudfoundry/noaa/v2 v2.2.0
 ## explicit; go 1.18
 github.com/cloudfoundry/noaa/v2
 github.com/cloudfoundry/noaa/v2/consumer
@@ -343,3 +343,4 @@ gopkg.in/tomb.v1
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
+# github.com/cloudfoundry/noaa/v2 => github.com/cloudfoundry/noaa/v2 v2.2.0


### PR DESCRIPTION
Pins noaa to v2.2.0 so that we don't lose the RecentLogs functionality that was removed in noaa v2.3.0.