### PR TITLE
fix: Replace deprecated `grpc.Dial` with `grpc.NewClient`

### DIFF
--- a/src/integration_tests/fakes/doppler.go
+++ b/src/integration_tests/fakes/doppler.go
@@ -21,7 +21,7 @@ func DopplerEgressV1Client(addr string) (func(), plumbing.DopplerClient) {
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	out, err := grpc.Dial(addr, grpc.WithTransportCredentials(creds))
+	out, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
 	Expect(err).ToNot(HaveOccurred())
 	return func() {
 		_ = out.Close()
@@ -37,7 +37,7 @@ func DopplerEgressV2Client(addr string) (func(), loggregator_v2.EgressClient) {
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	out, err := grpc.Dial(addr, grpc.WithTransportCredentials(creds))
+	out, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
 	Expect(err).ToNot(HaveOccurred())
 	return func() {
 		_ = out.Close()
@@ -53,7 +53,7 @@ func DopplerIngressV1Client(addr string) (func(), plumbing.DopplerIngestor_Pushe
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
 	Expect(err).ToNot(HaveOccurred())
 	client := plumbing.NewDopplerIngestorClient(conn)
 
@@ -91,7 +91,7 @@ func DopplerIngressV2Client(addr string) (func(), loggregator_v2.Ingress_SenderC
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
 	Expect(err).ToNot(HaveOccurred())
 	client := loggregator_v2.NewIngressClient(conn)
 

--- a/src/metricemitter/client.go
+++ b/src/metricemitter/client.go
@@ -79,7 +79,7 @@ func NewClient(addr string, opts ...ClientOption) (*Client, error) {
 		opt(client)
 	}
 
-	conn, err := grpc.Dial(addr, client.dialOpts...)
+	conn, err := grpc.NewClient(addr, client.dialOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/src/plumbing/pool.go
+++ b/src/plumbing/pool.go
@@ -79,3 +79,9 @@ func (p *Pool) connectToDoppler(addr string) {
 		return
 	}
 }
+
+func (p *Pool) Size() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.dopplers)
+}

--- a/src/plumbing/pool.go
+++ b/src/plumbing/pool.go
@@ -60,7 +60,7 @@ func (p *Pool) connectToDoppler(addr string) {
 	for {
 		log.Printf("adding doppler %s", addr)
 
-		conn, err := grpc.Dial(addr, p.dialOpts...)
+		conn, err := grpc.NewClient(addr, p.dialOpts...)
 		if err != nil {
 			// TODO: We don't yet understand how this could happen, we should.
 			// TODO: Replace with exponential backoff.

--- a/src/rlp-gateway/internal/ingress/log_client.go
+++ b/src/rlp-gateway/internal/ingress/log_client.go
@@ -33,13 +33,14 @@ func NewLogClient(creds credentials.TransportCredentials, logsProviderAddr strin
 }
 
 // Stream opens a new stream on the log client.
-func (c *LogClient) Stream(ctx context.Context, req *loggregator_v2.EgressBatchRequest) web.Receiver {
+func (c *LogClient) Stream(ctx context.Context, req *loggregator_v2.EgressBatchRequest) (web.Receiver, error) {
 	receiver, err := c.c.BatchedReceiver(ctx, req)
 	if err != nil {
 		log.Printf("failed to open stream from logs provider: %s", err)
+		return nil, err
 	}
 
-	return receiver.Recv
+	return receiver.Recv, nil
 }
 
 func (c *LogClient) Close() error {

--- a/src/rlp-gateway/internal/ingress/log_client.go
+++ b/src/rlp-gateway/internal/ingress/log_client.go
@@ -18,10 +18,9 @@ type LogClient struct {
 
 // NewClient dials the logs provider and returns a new log client.
 func NewLogClient(creds credentials.TransportCredentials, logsProviderAddr string) *LogClient {
-	conn, err := grpc.Dial(logsProviderAddr,
+	conn, err := grpc.NewClient(logsProviderAddr,
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(10*1024*1024)),
-		grpc.WithBlock(),
 	)
 	if err != nil {
 		log.Fatalf("failed to dial logs provider: %s", err)

--- a/src/rlp-gateway/internal/web/handler.go
+++ b/src/rlp-gateway/internal/web/handler.go
@@ -14,7 +14,7 @@ type Receiver func() (*loggregator_v2.EnvelopeBatch, error)
 // LogsProvder defines the interface for opening streams to the
 // logs provider
 type LogsProvider interface {
-	Stream(ctx context.Context, req *loggregator_v2.EgressBatchRequest) Receiver
+	Stream(ctx context.Context, req *loggregator_v2.EgressBatchRequest) (Receiver, error)
 }
 
 // Handler defines a struct for servering http endpoints

--- a/src/rlp-gateway/internal/web/json_error.go
+++ b/src/rlp-gateway/internal/web/json_error.go
@@ -13,6 +13,7 @@ var (
 	errCounterNamePresentButEmpty = newJSONError(http.StatusBadRequest, "missing_counter_name", "counter.name is invalid without value")
 	errGaugeNamePresentButEmpty   = newJSONError(http.StatusBadRequest, "missing_gauge_name", "gauge.name is invalid without value")
 	errStreamingUnsupported       = newJSONError(http.StatusInternalServerError, "streaming_unsupported", "request does not support streaming")
+	errStreamingUnavailable       = newJSONError(http.StatusServiceUnavailable, "streaming_unavailable", "streaming is temporarily unavailable")
 	errNotFound                   = newJSONError(http.StatusNotFound, "not_found", "resource not found")
 )
 

--- a/src/rlp/app/rlp_test.go
+++ b/src/rlp/app/rlp_test.go
@@ -243,7 +243,7 @@ func setupRLPClient(egressAddr string, testCerts *testservers.TestCerts) (loggre
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	conn, err := grpc.Dial(
+	conn, err := grpc.NewClient(
 		egressAddr,
 		grpc.WithTransportCredentials(ingressTLSCredentials),
 	)

--- a/src/rlp/internal/ingress/pool.go
+++ b/src/rlp/internal/ingress/pool.go
@@ -104,7 +104,7 @@ func (p *Pool) fetchClient(clients []unsafe.Pointer) loggregator_v2.EgressClient
 
 func (p *Pool) connectToDoppler(addr string, clients []unsafe.Pointer, idx int) {
 	for {
-		conn, err := grpc.Dial(addr, p.dialOpts...)
+		conn, err := grpc.NewClient(addr, p.dialOpts...)
 		if err != nil {
 			// TODO: We don't yet understand how this could happen, we should.
 			// TODO: Replace with exponential backoff.

--- a/src/rlp/internal/ingress/pool.go
+++ b/src/rlp/internal/ingress/pool.go
@@ -123,3 +123,9 @@ func (p *Pool) connectToDoppler(addr string, clients []unsafe.Pointer, idx int) 
 		return
 	}
 }
+
+func (p *Pool) Size() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.dopplers)
+}

--- a/src/router/app/router_test.go
+++ b/src/router/app/router_test.go
@@ -259,7 +259,7 @@ func grpcDial(addr string, g app.GRPC) *grpc.ClientConn {
 		panic(err)
 	}
 
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		panic(err)
 	}

--- a/src/router/internal/server/v1/doppler_server_test.go
+++ b/src/router/internal/server/v1/doppler_server_test.go
@@ -356,7 +356,7 @@ func startGRPCServer(ds plumbing.DopplerServer) net.Listener {
 }
 
 func establishClient(dopplerAddr string) (plumbing.DopplerClient, io.Closer) {
-	conn, err := grpc.Dial(dopplerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(dopplerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	Expect(err).ToNot(HaveOccurred())
 	c := plumbing.NewDopplerClient(conn)
 

--- a/src/router/internal/server/v1/ingestor_server_test.go
+++ b/src/router/internal/server/v1/ingestor_server_test.go
@@ -36,7 +36,7 @@ var _ = Describe("IngestorServer", func() {
 	}
 
 	var establishClient = func(dopplerAddr string) (plumbing.DopplerIngestorClient, io.Closer) {
-		conn, err := grpc.Dial(dopplerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.NewClient(dopplerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		Expect(err).ToNot(HaveOccurred())
 		c := plumbing.NewDopplerIngestorClient(conn)
 


### PR DESCRIPTION
# Description

Replaces `grpc.Dial` usage with `grpc.NewClient`. gRPC deprecated (and then briefly un-deprecated, but plan to re-deprecate) `Dial` and `DialContext` in favor of `NewClient`. See https://github.com/grpc/grpc-go/pull/7010 for more info about `NewClient`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
