### PR TITLE
fix: Ignore grpc.WithBlock deprecation warning

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -24,3 +24,8 @@ issues:
   - linters:
     - staticcheck
     text: "SA1019: grpc.Dial is deprecated"
+  # Exclude grpc.WithBlock deprecation warnings. WithBlock will be honored for
+  # the duration of the gRPC-Go 1.x line.
+  - linters:
+    - staticcheck
+    text: "SA1019: grpc.WithBlock is deprecated"


### PR DESCRIPTION
Continue to use grpc.WithBlock which will be honored for the duration of the gRPC-Go 1.x release line:
https://github.com/grpc/grpc-go/blob/v1.64.0/dialoptions.go#L304-L305

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
