### PR TITLE
ignore linter warnings for g115 rule

### DIFF
--- a/src/plumbing/envelope_averager.go
+++ b/src/plumbing/envelope_averager.go
@@ -27,7 +27,7 @@ func NewEnvelopeAverager() *EnvelopeAverager {
 func (a *EnvelopeAverager) Track(count, size int) {
 	for {
 		current := atomic.LoadUint64((*uint64)(&a.storage))
-		newValue := countAndTotal(current).encodeDelta(uint16(count), uint64(size))
+		newValue := countAndTotal(current).encodeDelta(uint16(count), uint64(size)) //#nosec G115
 
 		if atomic.CompareAndSwapUint64((*uint64)(&a.storage), current, uint64(newValue)) {
 			return
@@ -77,7 +77,7 @@ func (u countAndTotal) encodeDelta(count uint16, total uint64) countAndTotal {
 }
 
 func (u countAndTotal) decode() (count uint16, total uint64) {
-	count = uint16((uint64(u) & 0xFFFF000000000000) >> 48)
+	count = uint16((uint64(u) & 0xFFFF000000000000) >> 48) //#nosec G115
 	total = (uint64(u) & 0x0000FFFFFFFFFFFF)
 	return count, total
 }

--- a/src/rlp-gateway/internal/metrics/metrics.go
+++ b/src/rlp-gateway/internal/metrics/metrics.go
@@ -37,7 +37,7 @@ func (m *Metrics) NewCounter(name string) func(delta uint64) {
 	i := m.m.Get(name).(*expvar.Int)
 
 	return func(d uint64) {
-		i.Add(int64(d))
+		i.Add(int64(d)) //#nosec G115
 	}
 }
 

--- a/src/router/app/router.go
+++ b/src/router/app/router.go
@@ -235,7 +235,7 @@ func initV2Metrics(c *Config) *metricemitter.Client {
 		log.Fatalf("Could not use GRPC creds for server: %s", err)
 	}
 
-	batchInterval := time.Duration(c.MetricBatchIntervalMilliseconds) * time.Millisecond
+	batchInterval := time.Duration(c.MetricBatchIntervalMilliseconds) * time.Millisecond //#nosec G115
 
 	// metric-documentation-v2: setup function
 	metricClient, err := metricemitter.NewClient(

--- a/src/router/internal/server/v1/doppler_server.go
+++ b/src/router/internal/server/v1/doppler_server.go
@@ -151,7 +151,7 @@ func (m *DopplerServer) sendBatchData(req *plumbing.SubscriptionRequest, sender 
 
 	errStream := make(chan error, 1)
 	batcher := batching.NewByteBatcher(
-		int(m.batchSize),
+		int(m.batchSize), //#nosec G115
 		m.batchInterval,
 		&batchWriter{
 			sender:       sender,

--- a/src/router/internal/server/v2/egress_server.go
+++ b/src/router/internal/server/v2/egress_server.go
@@ -95,7 +95,7 @@ func (s *EgressServer) BatchedReceiver(
 
 	errStream := make(chan error, 1)
 	batcher := batching.NewV2EnvelopeBatcher(
-		int(s.batchSize),
+		int(s.batchSize), //#nosec G115
 		s.batchInterval,
 		&batchWriter{
 			sender:       sender,


### PR DESCRIPTION
# Description

ignore linter warnings for G115 https://github.com/securego/gosec/issues/1185

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
