### PR TITLE
Fix gosec lint errors

### DIFF
--- a/src/router/app/router.go
+++ b/src/router/app/router.go
@@ -113,13 +113,13 @@ func (d *Router) Start() {
 	v1Buf := diodes.NewManyToOneEnvelope(d.c.IngressBufferSize, gendiodes.AlertFunc(func(missed int) {
 		log.Printf("Dropped %d envelopes (v1 buffer)", missed)
 
-		ingressDropped.Increment(uint64(missed))
+		ingressDropped.Increment(uint64(missed)) // nolint:gosec
 	}))
 
 	v2Buf := diodes.NewManyToOneEnvelopeV2(d.c.IngressBufferSize, gendiodes.AlertFunc(func(missed int) {
 		log.Printf("Dropped %d envelopes (v2 buffer)", missed)
 
-		ingressDropped.Increment(uint64(missed))
+		ingressDropped.Increment(uint64(missed)) // nolint:gosec
 	}))
 
 	// metric-documentation-v2: (loggregator.doppler.subscriptions) Number of

--- a/src/router/internal/server/v1/doppler_server.go
+++ b/src/router/internal/server/v1/doppler_server.go
@@ -181,7 +181,7 @@ func (m *DopplerServer) sendBatchData(req *plumbing.SubscriptionRequest, sender 
 
 // Alert logs dropped message counts to stderr.
 func (m *DopplerServer) Alert(missed int) {
-	m.egressDropped.Increment(uint64(missed))
+	m.egressDropped.Increment(uint64(missed)) // nolint:gosec
 }
 
 func (m *DopplerServer) monitorContext(ctx context.Context, done *int64) {

--- a/src/router/internal/server/v2/egress_server.go
+++ b/src/router/internal/server/v2/egress_server.go
@@ -63,7 +63,7 @@ func NewEgressServer(
 
 // Alert logs dropped message counts to stderr.
 func (s *EgressServer) Alert(missed int) {
-	s.droppedMetric.Increment(uint64(missed))
+	s.droppedMetric.Increment(uint64(missed)) // nolint:gosec
 }
 
 // Receiver implements loggregator_v2.EgressServer.


### PR DESCRIPTION
# Description
Ignore gosec linting for integer conversion G115.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests (golangci-lint)
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes
