### PR TITLE
CAPI call migration from v2 to v3

### DIFF
--- a/src/rlp-gateway/internal/auth/capi_client.go
+++ b/src/rlp-gateway/internal/auth/capi_client.go
@@ -83,7 +83,7 @@ func (c *CAPIClient) IsAuthorized(sourceID, token string) bool {
 		return true
 	}
 
-	uri = fmt.Sprintf("%s/v2/service_instances/%s", c.externalCapi, sourceID)
+	uri = fmt.Sprintf("%s/v3/service_instances/%s", c.externalCapi, sourceID)
 	req, err = http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		log.Printf("failed to build authorize service instance access request: %s", err)
@@ -149,7 +149,7 @@ func (c *CAPIClient) AvailableSourceIDs(token string) []string {
 		sourceIDs = append(sourceIDs, v.Guid)
 	}
 
-	req, err = http.NewRequest(http.MethodGet, c.externalCapi+"/v2/service_instances", nil)
+	req, err = http.NewRequest(http.MethodGet, c.externalCapi+"/v3/service_instances", nil)
 	if err != nil {
 		log.Printf("failed to build authorize service instance access request: %s", err)
 		return nil
@@ -169,7 +169,7 @@ func (c *CAPIClient) AvailableSourceIDs(token string) []string {
 	}(resp)
 
 	if resp.StatusCode != http.StatusOK {
-		log.Printf("CAPI request failed (/v2/service_instances): %d", resp.StatusCode)
+		log.Printf("CAPI request failed (/v3/service_instances): %d", resp.StatusCode)
 		return nil
 	}
 

--- a/src/rlp-gateway/internal/auth/capi_client_test.go
+++ b/src/rlp-gateway/internal/auth/capi_client_test.go
@@ -51,7 +51,7 @@ var _ = Describe("CAPIClient", func() {
 			r = capiClient.requests[1]
 
 			Expect(r.Method).To(Equal(http.MethodGet))
-			Expect(r.URL.String()).To(Equal("http://external.capi.com/v2/service_instances/some-id"))
+			Expect(r.URL.String()).To(Equal("http://external.capi.com/v3/service_instances/some-id"))
 			Expect(r.Header.Get("Authorization")).To(Equal("some-token"))
 		})
 
@@ -121,7 +121,7 @@ var _ = Describe("CAPIClient", func() {
 
 			servicesReq := capiClient.requests[1]
 			Expect(servicesReq.Method).To(Equal(http.MethodGet))
-			Expect(servicesReq.URL.String()).To(Equal("http://external.capi.com/v2/service_instances"))
+			Expect(servicesReq.URL.String()).To(Equal("http://external.capi.com/v3/service_instances"))
 			Expect(servicesReq.Header.Get("Authorization")).To(Equal("some-token"))
 		})
 


### PR DESCRIPTION
# Description

The CAPI v2 is deprecated and will be deactivated in the cf-deployment. Therefore an update is needed to use the newer CAPI v3.

I've tested with curl if I can use the RLP API to read logs with the rlp `/v2/read` endpoint with an admin and non admin user and everything went well. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes
