### PR TITLE
Proper uint64 decrement

### DIFF
--- a/src/metricemitter/gauge.go
+++ b/src/metricemitter/gauge.go
@@ -48,7 +48,7 @@ func (m *Gauge) Increment(value float64) {
 
 // Decrement decrements the gauge by a specified value.
 func (m *Gauge) Decrement(value float64) {
-	atomic.AddUint64(&m.value, toUint64(-value, 2))
+	atomic.AddUint64(&m.value, ^uint64(toUint64(value, 2)-1))
 }
 
 // GetValue atomically returns the current value of the gauge.


### PR DESCRIPTION
# Description

This decrements the uint64 var in Gauge as per go.dev documentation, see https://pkg.go.dev/sync/atomic#AddUint64 .

Without this change a bunch of unit tests are failing on my ARM-based Mac.

My best guess as to why `atomic.AddUint64(&m.value, toUint64(-value, 2))` had worked before is that `toUint64(-value, 2)` produces the same result as `^uint64(toUint64(value, 2)-1)` on some CPU architectures.

Alternative to this change one may also consider the "less error-prone" `Uint64.Add` function (according [to documentation](https://pkg.go.dev/sync/atomic#AddUint64)).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes