### PR TITLE
Move to golangci v2

### DIFF
--- a/scripts/subtests/lint
+++ b/scripts/subtests/lint
@@ -9,7 +9,7 @@ set +e
 golangci_lint_executable=$(which golangci-lint)
 set -e
 if [ -z "${golangci_lint_executable}" ] || [ ! -x "${golangci_lint_executable}" ]; then
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 fi
 
 pushd "${SCRIPT_DIR}/../../src" > /dev/null

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   # Timeout for analysis, e.g. 30s, 5m.
   # Default: 1m
@@ -11,9 +13,28 @@ linters:
     - gocyclo
     # Inspects source code for security problems.
     - gosec
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 issues:
   # Disable max issues per linter.
   max-issues-per-linter: 0
   # Disable max same issues.
   max-same-issues: 0
+
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/src/integration_tests/fakes/doppler.go
+++ b/src/integration_tests/fakes/doppler.go
@@ -9,7 +9,7 @@ import (
 	"code.cloudfoundry.org/loggregator-release/src/testservers"
 	"google.golang.org/grpc"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:staticcheck
 )
 
 func DopplerEgressV1Client(addr string) (func(), plumbing.DopplerClient) {

--- a/src/integration_tests/router/router_suite_test.go
+++ b/src/integration_tests/router/router_suite_test.go
@@ -171,8 +171,8 @@ func primePumpV2(ingressClient loggregator_v2.Ingress_SenderClient, subscribeCli
 	Expect(err).ToNot(HaveOccurred())
 }
 
-var ErrorMissingOrigin = errors.New("Event not emitted due to missing origin information")
-var ErrorUnknownEventType = errors.New("Cannot create envelope for unknown event type")
+var ErrorMissingOrigin = errors.New("event not emitted due to missing origin information")
+var ErrorUnknownEventType = errors.New("cannot create envelope for unknown event type")
 
 func Wrap(event events.Event, origin string) (*events.Envelope, error) {
 	if origin == "" {

--- a/src/integration_tests/trafficcontroller/fake_uaa_server_test.go
+++ b/src/integration_tests/trafficcontroller/fake_uaa_server_test.go
@@ -22,7 +22,8 @@ func (h *FakeUaaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	token := r.FormValue("token")
 
-	if token == "iAmAnAdmin" {
+	switch token {
+	case "iAmAnAdmin":
 		authData := map[string]interface{}{
 			"scope": []string{
 				"doppler.firehose",
@@ -31,7 +32,7 @@ func (h *FakeUaaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		marshaled, _ := json.Marshal(authData)
 		_, _ = w.Write(marshaled)
-	} else if token == "iAmNotAnAdmin" {
+	case "iAmNotAnAdmin":
 		authData := map[string]interface{}{
 			"scope": []string{
 				"uaa.not-admin",
@@ -40,13 +41,13 @@ func (h *FakeUaaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		marshaled, _ := json.Marshal(authData)
 		_, _ = w.Write(marshaled)
-	} else if token == "expiredToken" {
+	case "expiredToken":
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("{\"error\":\"invalid_token\",\"error_description\":\"Token has expired\"}"))
-	} else if token == "invalidToken" {
+	case "invalidToken":
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("{\"invalidToken\":\"invalid_token\",\"error_description\":\"Invalid token (could not decode): invalidToken\"}"))
-	} else {
+	default:
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 

--- a/src/metricemitter/counter.go
+++ b/src/metricemitter/counter.go
@@ -35,7 +35,7 @@ func NewCounter(name, sourceID string, opts ...MetricOption) *Counter {
 		name:     name,
 		sourceID: sourceID,
 	}
-	m.Tagged.tags = make(map[string]*loggregator_v2.Value)
+	m.tags = make(map[string]*loggregator_v2.Value)
 
 	for _, opt := range opts {
 		opt(m.Tagged)

--- a/src/metricemitter/gauge.go
+++ b/src/metricemitter/gauge.go
@@ -27,7 +27,7 @@ func NewGauge(name, unit, sourceID string, opts ...MetricOption) *Gauge {
 		unit:     unit,
 		sourceID: sourceID,
 	}
-	m.Tagged.tags = make(map[string]*loggregator_v2.Value)
+	m.tags = make(map[string]*loggregator_v2.Value)
 
 	for _, opt := range opts {
 		opt(m.Tagged)

--- a/src/router/internal/server/v1/doppler_server.go
+++ b/src/router/internal/server/v1/doppler_server.go
@@ -104,11 +104,7 @@ func (m *DopplerServer) sendData(req *plumbing.SubscriptionRequest, sender sende
 	var done int64
 	go m.monitorContext(sender.Context(), &done)
 
-	for {
-		if atomic.LoadInt64(&done) > 0 {
-			break
-		}
-
+	for atomic.LoadInt64(&done) <= 0 {
 		data, ok := d.TryNext()
 		if !ok {
 			time.Sleep(10 * time.Millisecond)

--- a/src/router/internal/sinks/message_router_test.go
+++ b/src/router/internal/sinks/message_router_test.go
@@ -56,8 +56,8 @@ var _ = Describe("Message Router", func() {
 	})
 })
 
-var errorMissingOrigin = errors.New("Event not emitted due to missing origin information")
-var errorUnknownEventType = errors.New("Cannot create envelope for unknown event type")
+var errorMissingOrigin = errors.New("event not emitted due to missing origin information")
+var errorUnknownEventType = errors.New("cannot create envelope for unknown event type")
 
 func wrap(event events.Event, origin string) (*events.Envelope, error) {
 	if origin == "" {

--- a/src/testservers/router.go
+++ b/src/testservers/router.go
@@ -8,8 +8,8 @@ import (
 	envstruct "code.cloudfoundry.org/go-envstruct"
 	"code.cloudfoundry.org/loggregator-release/src/router/app"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
+	. "github.com/onsi/gomega"    //nolint:staticcheck
 	"github.com/onsi/gomega/gexec"
 )
 

--- a/src/testservers/traffic_controller.go
+++ b/src/testservers/traffic_controller.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"os/exec"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
+	. "github.com/onsi/gomega"    //nolint:staticcheck
 	"github.com/onsi/gomega/gexec"
 
 	envstruct "code.cloudfoundry.org/go-envstruct"

--- a/src/trafficcontroller/app/config.go
+++ b/src/trafficcontroller/app/config.go
@@ -80,11 +80,11 @@ func LoadConfig() (*Config, error) {
 
 func (c *Config) validate() error {
 	if c.SystemDomain == "" {
-		return errors.New("Need system domain in order to create the proxies")
+		return errors.New("need system domain in order to create the proxies")
 	}
 
 	if c.IP == "" {
-		return errors.New("Need IP address for access logging")
+		return errors.New("need IP address for access logging")
 	}
 
 	if len(c.GRPC.CAFile) == 0 {

--- a/src/trafficcontroller/internal/auth/log_access_authorizer.go
+++ b/src/trafficcontroller/internal/auth/log_access_authorizer.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	ErrNoAuthTokenProvided = errors.New("Error: Authorization not provided")
-	ErrInvalidAuthToken    = errors.New("Error: Invalid authorization")
+	ErrNoAuthTokenProvided = errors.New("authorization not provided")
+	ErrInvalidAuthToken    = errors.New("invalid authorization")
 )
 
 // TODO: We don't need to return an error and a status code. One will suffice.
@@ -25,7 +25,7 @@ func NewLogAccessAuthorizer(c *http.Client, disableAccessControl bool, apiHost s
 
 	return LogAccessAuthorizer(func(authToken string, target string) (int, error) {
 		if authToken == "" {
-			log.Println(ErrNoAuthTokenProvided)
+			log.Println("Error:", ErrNoAuthTokenProvided)
 			return http.StatusUnauthorized, ErrNoAuthTokenProvided
 		}
 

--- a/src/trafficcontroller/internal/auth/uaa_client.go
+++ b/src/trafficcontroller/internal/auth/uaa_client.go
@@ -45,7 +45,7 @@ func (c *uaaClient) GetAuthData(token string) (*AuthData, error) {
 	defer response.Body.Close()
 
 	if response.StatusCode == http.StatusUnauthorized {
-		return nil, errors.New("Invalid username/password")
+		return nil, errors.New("invalid username/password")
 	}
 
 	if response.StatusCode == http.StatusNotFound {
@@ -66,7 +66,7 @@ func (c *uaaClient) GetAuthData(token string) (*AuthData, error) {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, errors.New("Unknown error occurred")
+		return nil, errors.New("unknown error occurred")
 	}
 
 	var aData AuthData

--- a/src/trafficcontroller/internal/auth/uaa_client_test.go
+++ b/src/trafficcontroller/internal/auth/uaa_client_test.go
@@ -92,7 +92,7 @@ var _ = Describe("UaaClient", func() {
 
 			_, err := uaaClient.GetAuthData("500Please")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Unknown error occurred"))
+			Expect(err.Error()).To(Equal("unknown error occurred"))
 		})
 	})
 
@@ -102,7 +102,7 @@ var _ = Describe("UaaClient", func() {
 
 			_, err := uaaClient.GetAuthData("iAmAnAdmin")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Invalid username/password"))
+			Expect(err.Error()).To(Equal("invalid username/password"))
 		})
 	})
 
@@ -149,7 +149,8 @@ func (h *FakeUaaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	token := r.FormValue("token")
 
-	if token == "iAmAnAdmin" {
+	switch token {
+	case "iAmAnAdmin":
 		authData := map[string]interface{}{
 			"scope": []string{
 				"doppler.firehose",
@@ -161,7 +162,7 @@ func (h *FakeUaaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		_, err = w.Write(marshaled)
 		Expect(err).ToNot(HaveOccurred())
-	} else if token == "iAmNotAnAdmin" {
+	case "iAmNotAnAdmin":
 		authData := map[string]interface{}{
 			"scope": []string{
 				"uaa.not-admin",
@@ -173,19 +174,19 @@ func (h *FakeUaaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		_, err = w.Write(marshaled)
 		Expect(err).ToNot(HaveOccurred())
-	} else if token == "expiredToken" {
+	case "expiredToken":
 		w.WriteHeader(http.StatusBadRequest)
 		_, err := w.Write([]byte("{\"error\":\"invalid_token\",\"error_description\":\"Token has expired\"}"))
 		Expect(err).ToNot(HaveOccurred())
-	} else if token == "invalidToken" {
+	case "invalidToken":
 		w.WriteHeader(http.StatusBadRequest)
 		_, err := w.Write([]byte("{\"invalidToken\":\"invalid_token\",\"error_description\":\"Invalid token (could not decode): invalidToken\"}"))
 		Expect(err).ToNot(HaveOccurred())
-	} else if token == "invalidTokenWithBadResponse" {
+	case "invalidTokenWithBadResponse":
 		w.WriteHeader(http.StatusBadRequest)
 		_, err := w.Write([]byte("{"))
 		Expect(err).ToNot(HaveOccurred())
-	} else {
+	default:
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
# Description

Move to golangci-lint v2.

Issues were:

* [ST1005](https://staticcheck.dev/docs/checks/#ST1005): Same error string capitalization for nicer logs
    * Also changed two asserts in a test
    * Also removed "Error:" prefix
* [QF1006](https://staticcheck.dev/docs/checks/#QF1006): Lift `break` into loop condition
* [QF1008](https://staticcheck.dev/docs/checks/#QF1008): Omit an embedded field
* [QF1003](https://staticcheck.dev/docs/checks/#QF1003): Prefer tagged switch in some test files

Noteworthy changes in golangci-lint v2:

* New config format (migrated with `migrate` command)
* Default timeout is now 0 instead of 1 minute. See [here](https://github.com/golangci/golangci-lint/pull/5470/commits/d3bf353d4531c824201394821f0119a690a01519#r1968522617) for rationale. Kept ours unchanged for now.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes