### PR TITLE
Revert "Reuse installed ginkgo"

### DIFF
--- a/scripts/subtests/unit-test
+++ b/scripts/subtests/unit-test
@@ -11,8 +11,5 @@ if [ "${CI:-false}" = 'false' ]; then
 fi
 
 pushd "${SCRIPT_DIR}/../../src" > /dev/null
-    if ! command -v ginkgo &> /dev/null; then
-      go install github.com/onsi/ginkgo/v2/ginkgo@latest
-    fi
-    ginkgo $flags 
+    go run github.com/onsi/ginkgo/v2/ginkgo $flags
 popd > /dev/null


### PR DESCRIPTION
# Description

Using latest is actually not preferred over using the pinned version.

Partially reverts https://github.com/cloudfoundry/loggregator-release/pull/891 .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [ ] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
