### PR TITLE
feat(router): fan-out V2 PubSub Publish() via FanoutWriter

### DIFF
--- a/jobs/doppler/spec
+++ b/jobs/doppler/spec
@@ -59,6 +59,14 @@ properties:
     description: "The buffer size for egress traffic for the v1 loggregator"
     default: 1000
 
+  doppler.fanout_writer_enabled:
+    description: "Enable the fanout writer for the router"
+    default: false
+
+  doppler.publish_workers:
+    description: "The number of workers for the publish path. If set to 0, the number of workers will be equal to the number of CPUs."
+    default: 0
+
   metron_endpoint.host:
     description: "The host used to emit messages to the Metron agent"
     default: "127.0.0.1"

--- a/jobs/doppler/templates/bpm.yml.erb
+++ b/jobs/doppler/templates/bpm.yml.erb
@@ -13,5 +13,7 @@ processes:
       ROUTER_PPROF_PORT: "<%=  p("doppler.pprof_port") %>"
       INGRESS_BUFFER_SIZE: "<%=  p("doppler.ingress_buffer_size") %>"
       EGRESS_BUFFER_SIZE: "<%=  p("doppler.egress_buffer_size") %>"
+      ROUTER_FANOUT_WRITER_ENABLED: "<%=  p("doppler.fanout_writer_enabled") %>"
+      ROUTER_PUBLISH_WORKERS: "<%=  p("doppler.publish_workers") %>"
     limits:
       open_files: 65536

--- a/src/integration_tests/router/v2_egress_test.go
+++ b/src/integration_tests/router/v2_egress_test.go
@@ -145,6 +145,80 @@ var _ = Describe("V2 Egress", func() {
 			}).ShouldNot(BeEmpty())
 		})
 
+		Describe("with FanoutWriter enabled", func() {
+			var (
+				fanoutDopplerCleanup func()
+				fanoutIngressCleanup func()
+				fanoutEgressCleanup  func()
+
+				fanoutIngressClient loggregator_v2.Ingress_SenderClient
+				fanoutEgressClient  loggregator_v2.EgressClient
+			)
+
+			BeforeEach(func() {
+				var dopplerPorts testservers.RouterPorts
+
+				fanoutDopplerCleanup, dopplerPorts = testservers.StartRouter(
+					testservers.BuildRouterConfigWithFanoutWriter(0, 0, 4),
+				)
+				fanoutIngressCleanup, fanoutIngressClient = fakes.DopplerIngressV2Client(
+					fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC),
+				)
+				fanoutEgressCleanup, fanoutEgressClient = fakes.DopplerEgressV2Client(
+					fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC),
+				)
+			})
+
+			AfterEach(func() {
+				fanoutEgressCleanup()
+				fanoutIngressCleanup()
+				fanoutDopplerCleanup()
+			})
+
+			It("receives envelope batches", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				receiverClient, err := fanoutEgressClient.BatchedReceiver(ctx, &loggregator_v2.EgressBatchRequest{
+					Selectors: []*loggregator_v2.Selector{
+						{
+							Message: &loggregator_v2.Selector_Log{
+								Log: &loggregator_v2.LogSelector{},
+							},
+						},
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				defer func() {
+					err := receiverClient.CloseSend()
+					Expect(err).ToNot(HaveOccurred())
+				}()
+
+				done := make(chan struct{})
+				defer close(done)
+				go func() {
+					for {
+						_ = sendV2AppLog("some-test-app-id", "message", fanoutIngressClient)
+
+						select {
+						case <-time.After(500 * time.Millisecond):
+						case <-done:
+							return
+						}
+					}
+				}()
+
+				Eventually(func() []*loggregator_v2.Envelope {
+					resp, err := receiverClient.Recv()
+					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						return nil
+					}
+
+					return resp.GetBatch()
+				}).ShouldNot(BeEmpty())
+			})
+		})
+
 		Describe("requests with selectors", func() {
 			It("only returns envelopes of the requested type", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/src/router/app/config.go
+++ b/src/router/app/config.go
@@ -27,6 +27,8 @@ type Config struct {
 
 	IngressBufferSize               int    `env:"INGRESS_BUFFER_SIZE"`
 	EgressBufferSize                int    `env:"EGRESS_BUFFER_SIZE"`
+	PublishWorkers                  int    `env:"ROUTER_PUBLISH_WORKERS"`
+	FanoutWriterEnabled             bool   `env:"ROUTER_FANOUT_WRITER_ENABLED"`
 	UseRFC339                       bool   `env:"USE_RFC339"`
 	PProfPort                       uint32 `env:"ROUTER_PPROF_PORT"`
 	Agent                           Agent

--- a/src/router/app/router.go
+++ b/src/router/app/router.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"log"
+	"runtime"
 	"time"
 
 	"code.cloudfoundry.org/tlsconfig"
@@ -24,6 +25,7 @@ type Router struct {
 	c      *Config
 	server *server.Server
 	addrs  Addrs
+	fanout *v2.FanoutWriter
 }
 
 // NewRouter creates a new Router with the given options. Each provided
@@ -72,6 +74,17 @@ func WithBufferSizes(
 	return func(r *Router) {
 		r.c.IngressBufferSize = ingressBufferSize
 		r.c.EgressBufferSize = egressBufferSize
+	}
+}
+
+// WithFanoutWriter returns a RouterOption that enables or disables the
+// FanoutWriter feature. When disabled (default), the Repeater publishes
+// directly via v2PubSub.Publish(). When enabled, it fans out to workerCount workers.
+// Default worker count is GOMAXPROC when workerCount is 0
+func WithFanoutWriter(enabled bool, workerCount int) RouterOption {
+	return func(r *Router) {
+		r.c.FanoutWriterEnabled = enabled
+		r.c.PublishWorkers = workerCount
 	}
 }
 
@@ -200,8 +213,20 @@ func (d *Router) Start() {
 	messageRouter := sinks.NewMessageRouter(v1Router)
 	go messageRouter.Start(v1Buf)
 
-	repeater := v2.NewRepeater(v2PubSub.Publish, v2Buf.Next)
-	go repeater.Start()
+	workers := d.c.PublishWorkers
+	if workers <= 0 {
+		workers = runtime.GOMAXPROCS(0)
+	}
+
+	if d.c.FanoutWriterEnabled {
+		d.fanout = v2.NewFanoutWriter(v2PubSub.Publish, workers)
+		d.fanout.Start()
+		repeater := v2.NewRepeater(d.fanout.Write, v2Buf.Next)
+		go repeater.Start()
+	} else {
+		repeater := v2.NewRepeater(v2PubSub.Publish, v2Buf.Next)
+		go repeater.Start()
+	}
 
 	go d.server.Start()
 
@@ -222,6 +247,9 @@ func (d *Router) Addrs() Addrs {
 func (d *Router) Stop() {
 	// TODO: Drain
 	d.server.Stop()
+	if d.fanout != nil {
+		d.fanout.Stop()
+	}
 }
 
 func initV2Metrics(c *Config) *metricemitter.Client {

--- a/src/router/app/router_test.go
+++ b/src/router/app/router_test.go
@@ -227,6 +227,67 @@ var _ = Describe("Router", func() {
 			})
 		})
 	})
+
+	Describe("FanoutWriter enabled", func() {
+		var fanoutRouter *app.Router
+
+		BeforeEach(func() {
+			fanoutRouter = app.NewRouter(
+				grpcConfig,
+				app.WithBufferSizes(
+					10000,
+					1000,
+				),
+				app.WithFanoutWriter(true, 2),
+			)
+			fanoutRouter.Start()
+		})
+
+		AfterEach(func() {
+			fanoutRouter.Stop()
+		})
+
+		It("sends envelopes that can be read with an egress client", func() {
+			addrs := fanoutRouter.Addrs()
+
+			ingressClient := createRouterV2IngressClient(addrs.GRPC, grpcConfig)
+			egressClient := createRouterV2EgressClient(addrs.GRPC, grpcConfig)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			sender, err := ingressClient.Sender(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			go func() {
+				defer GinkgoRecover()
+				ticker := time.NewTicker(50 * time.Millisecond)
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-ticker.C:
+						err := sender.Send(genericLogEnvelope())
+						Expect(err).ToNot(HaveOccurred())
+					}
+				}
+			}()
+
+			rcvr, err := egressClient.BatchedReceiver(ctx, &loggregator_v2.EgressBatchRequest{
+				Selectors: []*loggregator_v2.Selector{
+					{
+						Message: &loggregator_v2.Selector_Log{
+							Log: &loggregator_v2.LogSelector{},
+						},
+					},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			batch, err := rcvr.Recv()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(batch.GetBatch()).ToNot(BeEmpty())
+		})
+	})
 })
 
 func genericLogEnvelope() *loggregator_v2.Envelope {

--- a/src/router/internal/server/v2/fanout_writer.go
+++ b/src/router/internal/server/v2/fanout_writer.go
@@ -1,0 +1,85 @@
+package v2
+
+import (
+	"context"
+	"sync"
+
+	"code.cloudfoundry.org/go-loggregator/v10/rpc/loggregator_v2"
+)
+
+// FanoutWriter fans out Write calls to N concurrent worker goroutines all
+// reading from a single shared channel. Its Write method satisfies the Writer
+// function signature, allowing it to be used with NewRepeater via f.Write.
+type FanoutWriter struct {
+	w       Writer
+	ch      chan *loggregator_v2.Envelope
+	workers int
+	wg      sync.WaitGroup
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+// FanoutOption configures a FanoutWriter.
+type FanoutOption func(*FanoutWriter)
+
+// WithBufferSize overrides the channel buffer size. The default is two slot
+// per worker. Use a larger value to decouple producer speed from worker
+// throughput.
+func WithBufferSize(n int) FanoutOption {
+	return func(f *FanoutWriter) {
+		f.ch = make(chan *loggregator_v2.Envelope, n)
+	}
+}
+
+// NewFanoutWriter creates a FanoutWriter with concurrent publisher
+// goroutines (workers) sharing a single channel. Call Start() before writing. The
+// channel buffer defaults to two slot per worker; use WithBufferSize to
+// override.
+func NewFanoutWriter(w Writer, workers int, opts ...FanoutOption) *FanoutWriter {
+	ctx, cancel := context.WithCancel(context.Background())
+	f := &FanoutWriter{
+		w:       w,
+		ch:      make(chan *loggregator_v2.Envelope, workers*2),
+		workers: workers,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+	for _, o := range opts {
+		o(f)
+	}
+	return f
+}
+
+// Start launches the worker goroutines. Must be called before Write.
+func (f *FanoutWriter) Start() {
+	for range f.workers {
+		f.wg.Add(1)
+		go f.writeWorker()
+	}
+}
+
+// Stop cancels the context (unblocking any Write blocked on ctx.Done), closes
+// the channel, and blocks until all workers have returned. Workers drain any
+// envelopes remaining in the buffer before exiting.
+func (f *FanoutWriter) Stop() {
+	f.cancel()
+	close(f.ch)
+	f.wg.Wait()
+}
+
+// Write sends e to the shared channel, blocking if the channel is full.
+// Drops e silently if the context has been cancelled. Satisfies the Writer
+// function signature.
+func (f *FanoutWriter) Write(e *loggregator_v2.Envelope) {
+	select {
+	case <-f.ctx.Done():
+	case f.ch <- e:
+	}
+}
+
+func (f *FanoutWriter) writeWorker() {
+	defer f.wg.Done()
+	for env := range f.ch {
+		f.w(env)
+	}
+}

--- a/src/router/internal/server/v2/fanout_writer_test.go
+++ b/src/router/internal/server/v2/fanout_writer_test.go
@@ -1,0 +1,36 @@
+package v2_test
+
+import (
+	"sync/atomic"
+
+	"code.cloudfoundry.org/go-loggregator/v10/rpc/loggregator_v2"
+	v2 "code.cloudfoundry.org/loggregator-release/src/router/internal/server/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FanoutWriter", func() {
+	It("delivers all written envelopes to the underlying writer", func() {
+		const total = 200
+		var count atomic.Int64
+		spy := func(_ *loggregator_v2.Envelope) { count.Add(1) }
+
+		f := v2.NewFanoutWriter(spy, 4)
+		f.Start()
+
+		for i := 0; i < total; i++ {
+			f.Write(&loggregator_v2.Envelope{})
+		}
+
+		Eventually(func() int64 { return count.Load() }).Should(BeEquivalentTo(total))
+	})
+
+	It("Stop returns without blocking", func() {
+		f := v2.NewFanoutWriter(func(*loggregator_v2.Envelope) {}, 2)
+		f.Start()
+
+		done := make(chan struct{})
+		go func() { f.Stop(); close(done) }()
+		Eventually(done).Should(BeClosed())
+	})
+})

--- a/src/router/internal/server/v2/pubsub_benchmark_test.go
+++ b/src/router/internal/server/v2/pubsub_benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -12,8 +13,9 @@ import (
 )
 
 var (
-	gen func() *loggregator_v2.Envelope
-	s   *v2.PubSub
+	gen   func() *loggregator_v2.Envelope
+	s     *v2.PubSub // NopSetter subscribers — baseline for NoOp benchmarks (serial and parallel)
+	sSpin *v2.PubSub // SleepSetter subscribers — realistic cost for BenchmarkDopplerRouter and BenchmarkDopplerRouterFanout
 )
 
 const numOfSubs = 100000
@@ -21,29 +23,38 @@ const numOfSubs = 100000
 func TestMain(m *testing.M) {
 	gen = randEnvGen()
 
-	s = v2.NewPubSub()
-	setter := NopSetter{}
-
-	for i := 0; i < numOfSubs; i++ {
-		s.Subscribe(
-			&loggregator_v2.EgressBatchRequest{
-				Selectors: []*loggregator_v2.Selector{
-					{
-						SourceId: fmt.Sprintf("%d", i%20000),
-						Message: &loggregator_v2.Selector_Log{
-							Log: &loggregator_v2.LogSelector{},
+	subscribe := func(ps *v2.PubSub, setter v2.DataSetter) {
+		for i := 0; i < numOfSubs; i++ {
+			ps.Subscribe(
+				&loggregator_v2.EgressBatchRequest{
+					Selectors: []*loggregator_v2.Selector{
+						{
+							SourceId: fmt.Sprintf("%d", i%20000),
+							Message: &loggregator_v2.Selector_Log{
+								Log: &loggregator_v2.LogSelector{},
+							},
 						},
 					},
 				},
-			},
-			setter,
-		)
+				setter,
+			)
+		}
 	}
+
+	s = v2.NewPubSub()
+	subscribe(s, NopSetter{})
+
+	sSpin = v2.NewPubSub()
+	subscribe(sSpin, SleepSetter{})
 
 	os.Exit(m.Run())
 }
 
-func BenchmarkDopplerRouter(b *testing.B) {
+// BenchmarkDopplerRouterNoOp measures the latency of a single envelope publication through
+// go-pubsub in a single thread with no parallelism. The tree holds 100k subscription
+// entries across 20k distinct SourceIds (5 per SourceId); each envelope matches and
+// dispatches to 5 subscribers. Uses NopSetter to isolate go-pubsub routing overhead.
+func BenchmarkDopplerRouterNoOp(b *testing.B) {
 	defer b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
@@ -52,9 +63,69 @@ func BenchmarkDopplerRouter(b *testing.B) {
 	}
 }
 
+// BenchmarkDopplerRouterParallelNoOp measures go-pubsub routing overhead with concurrent
+// callers. The tree holds 100k subscription entries across 20k distinct SourceIds (5 per
+// SourceId); each envelope matches 5 subscribers using NopSetter.
+// Note: the router V2 server reads from a Many-to-One diode that is not safe for
+// concurrent reads, so this benchmark does not reflect real production parallelism.
+// See BenchmarkDopplerRouterFanout for the accurate concurrent comparison.
+func BenchmarkDopplerRouterParallelNoOp(b *testing.B) {
+	defer b.ReportAllocs()
+
+	b.RunParallel(func(b *testing.PB) {
+		for b.Next() {
+			e := gen()
+			s.Publish(e)
+		}
+	})
+}
+
+// BenchmarkDopplerRouter measures the latency of a single envelope publication through
+// go-pubsub in a single thread, as used by the router V2 server. The tree holds 100k
+// subscription entries across 20k distinct SourceIds (5 per SourceId); each envelope
+// dispatches to 5 subscribers. SleepSetter sleeps 1 µs per call in an attempt to simulate realistic
+// per-subscriber cost.
+func BenchmarkDopplerRouter(b *testing.B) {
+	defer b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		e := gen()
+		sSpin.Publish(e)
+	}
+}
+
+
+// BenchmarkDopplerRouterFanout measures envelope publication throughput through
+// go-pubsub with FanoutWriter dispatching to concurrent workers. The tree holds 100k
+// subscription entries across 20k distinct SourceIds (5 per SourceId); each envelope
+// dispatches to 5 SleepSetter subscribers (1 µs each).
+func BenchmarkDopplerRouterFanout(b *testing.B) {
+	// Set workers equal to GOMAXPROCS so the -cpu flag controls the degree of parallelism.
+	workers := runtime.GOMAXPROCS(0)
+
+	f := v2.NewFanoutWriter(sSpin.Publish, workers)
+	f.Start()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		f.Write(gen())
+	}
+
+	f.Stop()
+}
+
 type NopSetter struct{}
 
 func (s NopSetter) Set(e *loggregator_v2.Envelope) {}
+
+// SleepSetter simulates a non-trivial subscriber by sleeping for 1 µs per
+// envelope. This makes Publish() more expensive than a no-op,
+// increasing the relative benefit of parallelism in parallelism benchmarks.
+type SleepSetter struct{}
+
+func (s SleepSetter) Set(e *loggregator_v2.Envelope) {
+	time.Sleep(time.Microsecond)
+}
 
 func randEnvGen() func() *loggregator_v2.Envelope {
 	var s []*loggregator_v2.Envelope

--- a/src/router/main.go
+++ b/src/router/main.go
@@ -36,6 +36,7 @@ func main() {
 			conf.IngressBufferSize,
 			conf.EgressBufferSize,
 		),
+		app.WithFanoutWriter(conf.FanoutWriterEnabled, conf.PublishWorkers),
 		app.WithMetricReporting(
 			conf.Agent,
 			conf.MetricBatchIntervalMilliseconds,

--- a/src/testservers/router.go
+++ b/src/testservers/router.go
@@ -30,6 +30,16 @@ func BuildRouterConfig(agentUDPPort, agentGRPCPort int) app.Config {
 	}
 }
 
+// BuildRouterConfigWithFanoutWriter returns a router config with the
+// FanoutWriter path enabled, for exercising the concurrent Publish() path
+// in integration tests.
+func BuildRouterConfigWithFanoutWriter(agentUDPPort, agentGRPCPort, workers int) app.Config {
+	conf := BuildRouterConfig(agentUDPPort, agentGRPCPort)
+	conf.FanoutWriterEnabled = true
+	conf.PublishWorkers = workers
+	return conf
+}
+
 type RouterPorts struct {
 	GRPC  int
 	PProf int


### PR DESCRIPTION
# Description

## Summary

The router's V2 path currently processes envelopes through a single `Repeater` goroutine calling `v2PubSub.Publish()` serially. Each `Publish()` call walks the subscriber tree and invokes every matching subscriber's `Set` sequentially, so envelopes queue up behind one another even when CPUs are available.

This PR introduces `FanoutWriter`, which sits between the `Repeater` and `v2PubSub.Publish()` as an opt-in feature. The Repeater feeds envelopes into a small buffered channel (2 slots per worker); N worker goroutines drain the channel and each calls `Publish()` independently. This allows multiple envelopes to be published concurrently — each worker handles a different envelope, and their `Publish()` calls run in parallel across CPUs. The per-envelope subscriber walk itself is unchanged. This can be activated as an opt-in feature by adding env variable `ROUTER_FANOUT_WRITER_ENABLED=true`

Concurrent publishing means envelopes may be delivered to subscribers in a different order than they were received. `loggregator-release` [already makes no guarantees for envelope ordering](https://github.com/cloudfoundry/loggregator-release#log-ordering) — the diode buffer is lossy by design, and subscribers are expected to handle out-of-order delivery.

## Concurrency concerns to be aware of:

- Many-to-one `go-diode` is safe for many writers and a single reader
- `v2PubSub.Publish()` is safe to be called by many go routines
- `server.v2.Repeater` is still a single go routine but no longer blocked by `v2PubSub.Publish()` on each Envelope. It now just forwards envelope pointers from the Many-to-one go-diode to a small buffered channel.

## Changes

- **`fanout_writer.go`** — new `FanoutWriter` type with `Start`/`Stop` lifecycle, a `Write` method satisfying the `Writer` function signature, and a `WithBufferSize` option.
- **`router.go` / `config.go`** — `FanoutWriter` is opt-in via two new env vars:
  - `ROUTER_FANOUT_WRITER_ENABLED` — enables the feature (default: `false`)
  - `ROUTER_PUBLISH_WORKERS` — number of concurrent workers (default: `GOMAXPROCS`)
- **`router_test.go`** - extended for when FanoutWriter is enabled
- **`fanout_writer_test.go`** — Ginkgo specs covering delivery correctness and clean `Stop` behaviour.
- **`pubsub_benchmark_test.go`** — extended with three new benchmarks (`BenchmarkDopplerRouterNoOp`, `BenchmarkDopplerRouterParallelNoOp`, `BenchmarkDopplerRouterFanout`) and a second fixture PubSub using `SleepSetter` (1 µs `time.Sleep` per subscriber) in an attempt to model realistic per-subscriber cost.

## Benchmark results

20k subscribers, 1 µs cost each, `GOMAXPROCS` swept via `-cpu 1,2,4,8,16` (n=10, `benchstat`):

```
                 │ bench_orig.txt │          bench_fanout.txt           │
                 │     sec/op     │   sec/op     vs base                │
DopplerRouter        5.015m ±  4%   4.426m ± 8%  -11.74% (p=0.000 n=10)
DopplerRouter-2      172.0µ ± 25%   115.2µ ± 9%  -33.02% (p=0.000 n=10)
DopplerRouter-4     163.90µ ±  6%   30.67µ ± 3%  -81.29% (p=0.000 n=10)
DopplerRouter-8    166.221µ ± 13%   7.487µ ± 8%  -95.50% (p=0.000 n=10)
DopplerRouter-16   167.942µ ±  6%   1.793µ ± 2%  -98.93% (p=0.000 n=10)
geomean              330.6µ         46.17µ       -86.03%
```

The original serializes `Publish()` calls, so adding CPUs gives no benefit (times plateau around 164–172 µs). With `FanoutWriter`, independent envelopes are published in parallel: at 16 CPUs it is ~94× faster

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
